### PR TITLE
Update permission schema usage

### DIFF
--- a/src/contexts/PermissionContext.tsx
+++ b/src/contexts/PermissionContext.tsx
@@ -150,9 +150,8 @@ export const PermissionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       // Fetch permissions for this role from database
       const { data: permissionsData, error: permissionsError } = await supabase
         .from('role_permissions')
-        .select('components, permission_level')
-        .eq('role', profileData.role)
-        .maybeSingle();
+        .select('component, permission_level')
+        .eq('role', profileData.role);
 
       if (permissionsError) {
         console.error("Error fetching permissions:", permissionsError);
@@ -172,11 +171,10 @@ export const PermissionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         admin_panel: 0
       };
 
-      if (permissionsData && permissionsData.components) {
-        const userPermissionLevel = permissionsData.permission_level;
-        (permissionsData.components as string[]).forEach((component) => {
-          if (component in finalPermissions) {
-            finalPermissions[component as AppArea] = userPermissionLevel;
+      if (permissionsData && permissionsData.length > 0) {
+        permissionsData.forEach((perm) => {
+          if (perm.component in finalPermissions) {
+            finalPermissions[perm.component as AppArea] = perm.permission_level;
           }
         });
       }

--- a/src/hooks/usePermissionManagement.ts
+++ b/src/hooks/usePermissionManagement.ts
@@ -10,7 +10,7 @@ interface RolePermission {
   id: string;
   role: UserRole;
   permission_level: number;
-  components: string[];
+  component: string;
 }
 
 export const usePermissionManagement = () => {
@@ -46,7 +46,7 @@ export const usePermissionManagement = () => {
         .from('role_permissions')
         .select('*')
         .eq('role', role)
-        .contains('components', [area]);
+        .eq('component', area);
 
       if (checkError && checkError.code !== 'PGRST116') {
         console.error("Error checking existing permission:", checkError);
@@ -74,7 +74,7 @@ export const usePermissionManagement = () => {
           .insert({
             role: role,
             permission_level: level,
-            components: [area]
+            component: area
           });
 
         if (insertError) {
@@ -95,8 +95,8 @@ export const usePermissionManagement = () => {
   };
 
   const getPermissionLevel = (area: AppArea, role: UserRole): number => {
-    const permission = permissions.find(p => 
-      p.role === role && p.components.includes(area)
+    const permission = permissions.find(
+      (p) => p.role === role && p.component === area
     );
     return permission?.permission_level || 0;
   };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -293,19 +293,19 @@ export type Database = {
       }
       role_permissions: {
         Row: {
-          components: Database["public"]["Enums"]["components"][]
+          component: Database["public"]["Enums"]["components"]
           id: string
           permission_level: number
           role: Database["public"]["Enums"]["user_role"]
         }
         Insert: {
-          components: Database["public"]["Enums"]["components"][]
+          component: Database["public"]["Enums"]["components"]
           id?: string
           permission_level?: number
           role: Database["public"]["Enums"]["user_role"]
         }
         Update: {
-          components?: Database["public"]["Enums"]["components"][]
+          component?: Database["public"]["Enums"]["components"]
           id?: string
           permission_level?: number
           role?: Database["public"]["Enums"]["user_role"]

--- a/src/utils/permissionSync.ts
+++ b/src/utils/permissionSync.ts
@@ -32,13 +32,12 @@ export const loadPermissionsFromDatabase = async (): Promise<PermissionMatrix> =
     });
 
     // Sobrescrever com dados do banco
-    dbPermissions?.forEach(permission => {
-      permission.components.forEach((component: string) => {
-        if (!matrix[component]) {
-          matrix[component] = {};
-        }
-        matrix[component][permission.role] = permission.permission_level;
-      });
+    dbPermissions?.forEach((permission) => {
+      const component = permission.component as string;
+      if (!matrix[component]) {
+        matrix[component] = {};
+      }
+      matrix[component][permission.role] = permission.permission_level;
     });
 
     return matrix;
@@ -75,8 +74,8 @@ export const syncPermissionsToDatabase = async () => {
       Object.entries(rule.roles).forEach(([role, level]) => {
         insertData.push({
           role,
-          permission_level: level,
-          components: [area]
+          component: area,
+          permission_level: level
         });
       });
     });

--- a/src/utils/permissionUtils.ts
+++ b/src/utils/permissionUtils.ts
@@ -61,7 +61,7 @@ export const fetchUserProfileAndPermissions = async (userId: string | undefined)
     // Fetch permissions for this role from database
     const { data: permissionsData, error: permissionsError } = await supabase
       .from('role_permissions')
-      .select('components, permission_level')
+      .select('component, permission_level')
       .eq('role', profileData.role);
 
     if (permissionsError) {
@@ -80,9 +80,8 @@ export const fetchUserProfileAndPermissions = async (userId: string | undefined)
 
     if (permissionsData && permissionsData.length > 0) {
       permissionsData.forEach((permission) => {
-        (permission.components as string[]).forEach((component) => {
-          permissionLevels[component as AppArea] = permission.permission_level;
-        });
+        permissionLevels[permission.component as AppArea] =
+          permission.permission_level;
       });
     }
 


### PR DESCRIPTION
## Summary
- migrate role permission model to use a single `component`
- update user permission utilities
- fetch permission data without `maybeSingle`
- revise permission sync and management hooks
- regenerate Supabase types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485bc6ab08832896e6571895a4f59b