### PR TITLE
Update permission schema usage

### DIFF
--- a/src/components/pendings/PendencyDashboard.tsx
+++ b/src/components/pendings/PendencyDashboard.tsx
@@ -3,10 +3,15 @@ import React from 'react';
 import { ProductivityDashboard } from './ProductivityDashboard';
 import { SmartActionsList } from './SmartActionsList';
 import { useTaskAutomation } from '@/hooks/useTaskAutomation';
+import { useVehiclePendencies } from '@/hooks/useVehiclePendencies';
+import { useConsolidatedTasks } from '@/hooks/useConsolidatedTasks';
 
 const PendencyDashboard: React.FC = () => {
   // Sincronização única ao inicializar (não mais loop infinito)
   const { isAutoSyncing } = useTaskAutomation();
+  const { stats } = useVehiclePendencies();
+  const { data: tasks = [] } = useConsolidatedTasks();
+  const pendingTasks = tasks.filter(t => t.status === 'pending');
 
   return (
     <div className="content-container py-6">
@@ -17,6 +22,9 @@ const PendencyDashboard: React.FC = () => {
             <p className="text-muted-foreground">
               Sistema inteligente com detecção automática e workflows otimizados
               {isAutoSyncing && ' (Sincronizando...)'}
+            </p>
+            <p className="text-sm text-muted-foreground mt-1">
+              Pendências: {stats.total} | Tarefas pendentes: {pendingTasks.length}
             </p>
           </div>
         </div>

--- a/src/components/pendings/SmartActionsList.tsx
+++ b/src/components/pendings/SmartActionsList.tsx
@@ -103,6 +103,8 @@ export const SmartActionsList: React.FC = () => {
     return aPriority - bPriority;
   });
 
+  const totalActions = sortedActions.length;
+
   const handleRefresh = () => {
     console.log('Manual refresh triggered');
     syncTasks.mutate();
@@ -119,7 +121,10 @@ export const SmartActionsList: React.FC = () => {
     <Card>
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle>Ações Prioritárias</CardTitle>
+          <CardTitle className="flex items-center gap-2">
+            Ações Prioritárias
+            <span className="text-sm text-muted-foreground">({totalActions})</span>
+          </CardTitle>
           <Button
             variant="outline"
             size="sm"

--- a/src/contexts/PermissionContext.tsx
+++ b/src/contexts/PermissionContext.tsx
@@ -150,9 +150,8 @@ export const PermissionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       // Fetch permissions for this role from database
       const { data: permissionsData, error: permissionsError } = await supabase
         .from('role_permissions')
-        .select('components, permission_level')
-        .eq('role', profileData.role)
-        .maybeSingle();
+        .select('component, permission_level')
+        .eq('role', profileData.role);
 
       if (permissionsError) {
         console.error("Error fetching permissions:", permissionsError);
@@ -172,11 +171,10 @@ export const PermissionProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         admin_panel: 0
       };
 
-      if (permissionsData && permissionsData.components) {
-        const userPermissionLevel = permissionsData.permission_level;
-        (permissionsData.components as string[]).forEach((component) => {
-          if (component in finalPermissions) {
-            finalPermissions[component as AppArea] = userPermissionLevel;
+      if (permissionsData && permissionsData.length > 0) {
+        permissionsData.forEach((perm) => {
+          if (perm.component in finalPermissions) {
+            finalPermissions[perm.component as AppArea] = perm.permission_level;
           }
         });
       }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -293,19 +293,19 @@ export type Database = {
       }
       role_permissions: {
         Row: {
-          components: Database["public"]["Enums"]["components"][]
+          component: Database["public"]["Enums"]["components"]
           id: string
           permission_level: number
           role: Database["public"]["Enums"]["user_role"]
         }
         Insert: {
-          components: Database["public"]["Enums"]["components"][]
+          component: Database["public"]["Enums"]["components"]
           id?: string
           permission_level?: number
           role: Database["public"]["Enums"]["user_role"]
         }
         Update: {
-          components?: Database["public"]["Enums"]["components"][]
+          component?: Database["public"]["Enums"]["components"]
           id?: string
           permission_level?: number
           role?: Database["public"]["Enums"]["user_role"]

--- a/src/utils/permissionSync.ts
+++ b/src/utils/permissionSync.ts
@@ -32,13 +32,12 @@ export const loadPermissionsFromDatabase = async (): Promise<PermissionMatrix> =
     });
 
     // Sobrescrever com dados do banco
-    dbPermissions?.forEach(permission => {
-      permission.components.forEach((component: string) => {
-        if (!matrix[component]) {
-          matrix[component] = {};
-        }
-        matrix[component][permission.role] = permission.permission_level;
-      });
+    dbPermissions?.forEach((permission) => {
+      const component = permission.component as string;
+      if (!matrix[component]) {
+        matrix[component] = {};
+      }
+      matrix[component][permission.role] = permission.permission_level;
     });
 
     return matrix;
@@ -73,11 +72,13 @@ export const syncPermissionsToDatabase = async () => {
     
     Object.entries(permissionRules).forEach(([area, rule]) => {
       Object.entries(rule.roles).forEach(([role, level]) => {
-        insertData.push({
-          role,
-          permission_level: level,
-          components: [area]
-        });
+        if (level > 0) {
+          insertData.push({
+            role,
+            component: area,
+            permission_level: level
+          });
+        }
       });
     });
 

--- a/src/utils/permissionUtils.ts
+++ b/src/utils/permissionUtils.ts
@@ -61,7 +61,7 @@ export const fetchUserProfileAndPermissions = async (userId: string | undefined)
     // Fetch permissions for this role from database
     const { data: permissionsData, error: permissionsError } = await supabase
       .from('role_permissions')
-      .select('components, permission_level')
+      .select('component, permission_level')
       .eq('role', profileData.role);
 
     if (permissionsError) {
@@ -80,9 +80,8 @@ export const fetchUserProfileAndPermissions = async (userId: string | undefined)
 
     if (permissionsData && permissionsData.length > 0) {
       permissionsData.forEach((permission) => {
-        (permission.components as string[]).forEach((component) => {
-          permissionLevels[component as AppArea] = permission.permission_level;
-        });
+        permissionLevels[permission.component as AppArea] =
+          permission.permission_level;
       });
     }
 


### PR DESCRIPTION
## Summary
- migrate role permission model to use a single `component`
- update user permission utilities
- fetch permission data without `maybeSingle`
- revise permission sync and management hooks
- regenerate Supabase types
- delete permissions when value is set to zero
- skip zero-level rules during sync
- show action count and pendency totals on pendency dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485bc6ab08832896e6571895a4f59b