### PR TITLE
Improve permission matrix and pendings dashboard

### DIFF
--- a/src/components/pendings/PendencyDashboard.tsx
+++ b/src/components/pendings/PendencyDashboard.tsx
@@ -1,7 +1,10 @@
 
 import React from 'react';
 import { ProductivityDashboard } from './ProductivityDashboard';
+import PendingMetrics from './PendingMetrics';
+import PendingCharts from './PendingCharts';
 import { SmartActionsList } from './SmartActionsList';
+import SmartInsights from './SmartInsights';
 import { useTaskAutomation } from '@/hooks/useTaskAutomation';
 
 const PendencyDashboard: React.FC = () => {
@@ -23,7 +26,10 @@ const PendencyDashboard: React.FC = () => {
 
         <div className="p-6 space-y-6">
           <ProductivityDashboard />
+          <PendingMetrics />
+          <PendingCharts />
           <SmartActionsList />
+          <SmartInsights insights={[]} onActionClick={() => {}} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- delete role permission entries when level is set to `0`
- show pending metrics, charts and insights on pendings dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485faccac08328bb1eed971c4d0f79