### PR TITLE
Audit dashboard: add sortable grid view, server sort params, Supabase client null-safety and styles

### DIFF
--- a/app/api/v1/auditoria/dashboard/route.ts
+++ b/app/api/v1/auditoria/dashboard/route.ts
@@ -24,6 +24,21 @@ function normalizeAuditSearchMode(value: string) {
   }
 }
 
+function normalizeAuditSortBy(value: string) {
+  switch (value) {
+    case "table":
+    case "action":
+    case "author":
+      return value;
+    default:
+      return "createdAt";
+  }
+}
+
+function normalizeAuditSortDir(value: string) {
+  return value === "asc" ? "asc" : "desc";
+}
+
 function normalizeSearchText(value: unknown) {
   if (value == null) return "";
 
@@ -108,14 +123,26 @@ export async function GET(req: NextRequest) {
     const dateTo = (req.nextUrl.searchParams.get("date_to") ?? "").trim();
     const search = normalizeAuditSearchTerm((req.nextUrl.searchParams.get("search") ?? "").trim());
     const searchMode = normalizeAuditSearchMode((req.nextUrl.searchParams.get("search_mode") ?? "").trim());
+    const sortBy = normalizeAuditSortBy((req.nextUrl.searchParams.get("sort_by") ?? "").trim());
+    const sortDir = normalizeAuditSortDir((req.nextUrl.searchParams.get("sort_dir") ?? "").trim());
 
-    let rowsQuery = supabase.from("log_alteracoes").select("*", { count: "exact" }).order("data_hora", { ascending: false });
+    let rowsQuery = supabase.from("log_alteracoes").select("*", { count: "exact" });
 
     if (tabela) rowsQuery = rowsQuery.eq("tabela", tabela);
     if (acao) rowsQuery = rowsQuery.eq("acao", acao);
     if (autor) rowsQuery = rowsQuery.eq("autor", autor);
     if (dateFrom) rowsQuery = rowsQuery.gte("data_hora", `${dateFrom}T00:00:00`);
     if (dateTo) rowsQuery = rowsQuery.lte("data_hora", endOfDayIso(dateTo));
+
+    if (sortBy === "table") {
+      rowsQuery = rowsQuery.order("tabela", { ascending: sortDir === "asc" }).order("data_hora", { ascending: false });
+    } else if (sortBy === "action") {
+      rowsQuery = rowsQuery.order("acao", { ascending: sortDir === "asc" }).order("data_hora", { ascending: false });
+    } else if (sortBy === "author") {
+      rowsQuery = rowsQuery.order("autor", { ascending: sortDir === "asc" }).order("data_hora", { ascending: false });
+    } else {
+      rowsQuery = rowsQuery.order("data_hora", { ascending: sortDir === "asc" });
+    }
     const [{ data: rows, error: rowsError, count }, { data: actionRows, error: actionsError }, { data: authorRows, error: authorsError }, { data: tableRows, error: tablesError }] =
       await Promise.all([
         search ? rowsQuery : rowsQuery.range(from, to),

--- a/app/globals.css
+++ b/app/globals.css
@@ -886,6 +886,82 @@ button {
   gap: 12px;
 }
 
+.audit-grid-wrap {
+  overflow: auto;
+  border: 1px solid rgba(24, 49, 38, 0.14);
+  border-radius: 12px;
+}
+
+.audit-grid-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 1060px;
+}
+
+.audit-grid-table th,
+.audit-grid-table td {
+  border-bottom: 1px solid #e8edf4;
+  padding: 8px 10px;
+  vertical-align: top;
+  text-align: left;
+  font-size: 0.82rem;
+}
+
+.audit-grid-table td pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font: 0.78rem/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.audit-grid-table th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #f6f9ff;
+}
+
+.audit-grid-sort {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: #284469;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.audit-grid-row {
+  cursor: pointer;
+  background: linear-gradient(180deg, #fff7cb 0%, #fffbe3 100%);
+}
+
+.audit-grid-row:hover {
+  background: linear-gradient(180deg, #fff2ae 0%, #fff9d6 100%);
+}
+
+.audit-grid-expanded-row td {
+  background: #f8fbff;
+}
+
+.audit-grid-expanded-content {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+  color: #3d536f;
+  font-size: 0.8rem;
+}
+
+.audit-grid-empty {
+  display: grid;
+  place-items: center;
+  min-height: 180px;
+  text-align: center;
+  color: var(--muted);
+}
+
 .audit-card {
   border: 1px solid rgba(24, 49, 38, 0.1);
   border-radius: 14px;

--- a/components/audit/audit-log-dashboard.tsx
+++ b/components/audit/audit-log-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import {
   ApiClientError,
   fetchAuditDashboard,
@@ -22,6 +22,17 @@ export type AuditDashboardFilterDefaults = {
 type AuditLogDashboardProps = {
   requestAuth: RequestAuth;
   initialFilters?: AuditDashboardFilterDefaults;
+};
+
+type AuditGridSortColumn = "createdAt" | "table" | "action" | "field" | "before" | "after";
+type AuditGridSortDirection = "asc" | "desc";
+
+type AuditDiffRow = {
+  after: unknown;
+  before: unknown;
+  entry: AuditDashboardEntry;
+  field: string;
+  id: string;
 };
 
 const AUDIT_PAGE_SIZE_OPTIONS = [12, 24, 48] as const;
@@ -87,8 +98,24 @@ function flattenAuditDiff(
   ];
 }
 
-function buildAuditDiffs(entry: AuditDashboardEntry) {
-  return flattenAuditDiff(entry.beforeData, entry.afterData);
+function buildAuditDiffRows(entry: AuditDashboardEntry): AuditDiffRow[] {
+  const diffs = flattenAuditDiff(entry.beforeData, entry.afterData);
+  const fallbackDiff = {
+    after: entry.afterData ?? entry.beforeData,
+    before: undefined,
+    field: "Sem diferenca estruturada"
+  };
+  const resolvedDiffs = diffs.length > 0 ? diffs : [fallbackDiff];
+
+  return resolvedDiffs.map((diff, index) => ({
+    ...diff,
+    entry,
+    id: `${entry.id}::${diff.field}::${index}`
+  }));
+}
+
+function toComparable(value: unknown) {
+  return stringifyAuditValue(value).toLocaleLowerCase("pt-BR");
 }
 
 export function AuditLogDashboard({ requestAuth, initialFilters }: AuditLogDashboardProps) {
@@ -102,7 +129,9 @@ export function AuditLogDashboard({ requestAuth, initialFilters }: AuditLogDashb
   const [dateTo, setDateTo] = useState(initialFilters?.dateTo ?? "");
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState<number>(AUDIT_PAGE_SIZE_OPTIONS[0]);
-  const [expandedEntryIds, setExpandedEntryIds] = useState<Record<string, boolean>>({});
+  const [expandedRowIds, setExpandedRowIds] = useState<Record<string, boolean>>({});
+  const [sortColumn, setSortColumn] = useState<AuditGridSortColumn>("createdAt");
+  const [sortDirection, setSortDirection] = useState<AuditGridSortDirection>("desc");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [payload, setPayload] = useState<AuditDashboardPayload | null>(null);
@@ -125,6 +154,15 @@ export function AuditLogDashboard({ requestAuth, initialFilters }: AuditLogDashb
       requestAuth,
       page,
       pageSize,
+      sortBy:
+        sortColumn === "table"
+          ? "table"
+          : sortColumn === "action"
+            ? "action"
+            : sortColumn === "createdAt"
+              ? "createdAt"
+              : undefined,
+      sortDir: sortDirection,
       autor: autor || undefined,
       tabela: tabela || undefined,
       acao: acao || undefined,
@@ -149,9 +187,9 @@ export function AuditLogDashboard({ requestAuth, initialFilters }: AuditLogDashb
     return () => {
       active = false;
     };
-  }, [acao, autor, dateFrom, dateTo, page, pageSize, requestAuth, search, searchMode, tabela]);
+  }, [acao, autor, dateFrom, dateTo, page, pageSize, requestAuth, search, searchMode, sortColumn, sortDirection, tabela]);
 
-  const rows = payload?.rows ?? [];
+  const rows = useMemo(() => payload?.rows ?? [], [payload?.rows]);
   const pagination = payload?.pagination;
   const filterOptions = payload?.filters;
   const hasFilters = Boolean(searchInput || autor || acao || tabela || dateFrom || dateTo || searchMode !== "search");
@@ -160,13 +198,71 @@ export function AuditLogDashboard({ requestAuth, initialFilters }: AuditLogDashb
     return `${pagination.total} registro(s)`;
   }, [pagination]);
 
+  const diffRows = useMemo(() => {
+    const flattened = rows.flatMap((entry) => buildAuditDiffRows(entry));
+
+    return [...flattened].sort((left, right) => {
+      if (sortColumn === "field") {
+        return sortDirection === "asc"
+          ? left.field.localeCompare(right.field, "pt-BR", { sensitivity: "base" })
+          : right.field.localeCompare(left.field, "pt-BR", { sensitivity: "base" });
+      }
+
+      if (sortColumn === "before") {
+        const leftText = toComparable(left.before);
+        const rightText = toComparable(right.before);
+        return sortDirection === "asc" ? leftText.localeCompare(rightText, "pt-BR") : rightText.localeCompare(leftText, "pt-BR");
+      }
+
+      if (sortColumn === "after") {
+        const leftText = toComparable(left.after);
+        const rightText = toComparable(right.after);
+        return sortDirection === "asc" ? leftText.localeCompare(rightText, "pt-BR") : rightText.localeCompare(leftText, "pt-BR");
+      }
+
+      if (sortColumn === "table") {
+        return sortDirection === "asc"
+          ? (left.entry.table ?? "").localeCompare(right.entry.table ?? "", "pt-BR", { sensitivity: "base" })
+          : (right.entry.table ?? "").localeCompare(left.entry.table ?? "", "pt-BR", { sensitivity: "base" });
+      }
+
+      if (sortColumn === "action") {
+        return sortDirection === "asc"
+          ? (left.entry.actionLabel ?? "").localeCompare(right.entry.actionLabel ?? "", "pt-BR", { sensitivity: "base" })
+          : (right.entry.actionLabel ?? "").localeCompare(left.entry.actionLabel ?? "", "pt-BR", { sensitivity: "base" });
+      }
+
+      const leftDate = new Date(left.entry.createdAt).getTime();
+      const rightDate = new Date(right.entry.createdAt).getTime();
+      return sortDirection === "asc" ? leftDate - rightDate : rightDate - leftDate;
+    });
+  }, [rows, sortColumn, sortDirection]);
+
+  function toggleSort(column: AuditGridSortColumn) {
+    setPage(1);
+    setSortColumn((currentColumn) => {
+      if (currentColumn === column) {
+        setSortDirection((currentDirection) => (currentDirection === "asc" ? "desc" : "asc"));
+        return currentColumn;
+      }
+
+      setSortDirection(column === "createdAt" ? "desc" : "asc");
+      return column;
+    });
+  }
+
+  function sortIndicator(column: AuditGridSortColumn) {
+    if (sortColumn !== column) return "↕";
+    return sortDirection === "asc" ? "▲" : "▼";
+  }
+
   return (
     <div className="audit-dashboard">
       <section className="sheet-panel audit-dashboard-panel">
         <header className="sheet-panel-head audit-dashboard-head">
           <div className="sheet-panel-head-main audit-dashboard-head-main">
             <strong className="sheet-panel-head-title">Dashboard de auditoria</strong>
-            <span className="audit-dashboard-subtitle">Logs ordenados do mais recente para o mais antigo.</span>
+            <span className="audit-dashboard-subtitle">Visualizacao em grade com destaque das mudancas.</span>
           </div>
           <div className="audit-dashboard-summary">
             <span>{totalLabel}</span>
@@ -274,7 +370,7 @@ export function AuditLogDashboard({ requestAuth, initialFilters }: AuditLogDashb
             </select>
           </label>
           <label className="sheet-inline-field audit-filter-field audit-filter-field-page">
-            Cards por pagina
+            Linhas por pagina
             <select
               value={pageSize}
               onChange={(event) => {
@@ -312,84 +408,110 @@ export function AuditLogDashboard({ requestAuth, initialFilters }: AuditLogDashb
 
         {error ? <p className="sheet-error audit-dashboard-error">Erro: {error}</p> : null}
 
-        <div className="audit-card-grid">
-          {!loading && rows.length === 0 ? (
-            <article className="audit-card audit-card-empty">
+        <div className="audit-grid-wrap">
+          {!loading && diffRows.length === 0 ? (
+            <article className="audit-grid-empty">
               <strong>Nenhum log encontrado.</strong>
               <p>Ajuste os filtros para ampliar a busca.</p>
             </article>
           ) : null}
 
-          {rows.map((entry) => {
-            const diffs = buildAuditDiffs(entry);
-            const fallbackDiff = {
-              after: entry.afterData ?? entry.beforeData,
-              before: undefined,
-              field: "Sem diferenca estruturada"
-            };
-            const resolvedDiffs = diffs.length > 0 ? diffs : [fallbackDiff];
-            const isExpanded = Boolean(expandedEntryIds[entry.id]);
-            const visibleDiffs = isExpanded ? resolvedDiffs : resolvedDiffs.slice(0, 1);
-            const hiddenDiffCount = Math.max(0, resolvedDiffs.length - visibleDiffs.length);
+          {diffRows.length > 0 ? (
+            <table className="audit-grid-table">
+              <thead>
+                <tr>
+                  <th>
+                    <button type="button" className="audit-grid-sort" onClick={() => toggleSort("createdAt")}>
+                      Atualizacao {sortIndicator("createdAt")}
+                    </button>
+                  </th>
+                  <th>
+                    <button type="button" className="audit-grid-sort" onClick={() => toggleSort("table")}>
+                      Tabela {sortIndicator("table")}
+                    </button>
+                  </th>
+                  <th>
+                    <button type="button" className="audit-grid-sort" onClick={() => toggleSort("action")}>
+                      Operacao {sortIndicator("action")}
+                    </button>
+                  </th>
+                  <th>
+                    <button type="button" className="audit-grid-sort" onClick={() => toggleSort("field")}>
+                      Campo alterado {sortIndicator("field")}
+                    </button>
+                  </th>
+                  <th>
+                    <button type="button" className="audit-grid-sort" onClick={() => toggleSort("before")}>
+                      Valor anterior {sortIndicator("before")}
+                    </button>
+                  </th>
+                  <th>
+                    <button type="button" className="audit-grid-sort" onClick={() => toggleSort("after")}>
+                      Valor atualizado {sortIndicator("after")}
+                    </button>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {diffRows.map((row) => {
+                  const isExpanded = Boolean(expandedRowIds[row.id]);
 
-            return (
-              <article key={entry.id} className="audit-card">
-                <header className="audit-card-head">
-                  <div className="audit-card-badges">
-                    <span className="audit-chip audit-chip-action">{entry.actionLabel}</span>
-                    <span className="audit-chip">{entry.table}</span>
-                    {entry.pk ? <span className="audit-chip">PK {entry.pk}</span> : null}
-                    {entry.inBatch ? <span className="audit-chip">Lote</span> : null}
-                  </div>
-                  <strong>{entry.authorName}</strong>
-                  <div className="audit-card-meta">
-                    <span>{formatAuditDateTime(entry.createdAt)}</span>
-                    {entry.authorRole ? <span>{entry.authorRole}</span> : null}
-                    {entry.authorEmail ? <span>{entry.authorEmail}</span> : null}
-                  </div>
-                </header>
-
-                {entry.details ? <p className="audit-card-details">{entry.details}</p> : null}
-
-                <div className="audit-diff-list">
-                  {visibleDiffs.map((diff) => (
-                    <section key={`${entry.id}-${diff.field}`} className="audit-diff-row">
-                      <strong>{diff.field}</strong>
-                      <div className="audit-diff-values">
-                        {diff.before !== undefined ? (
-                          <div className="audit-diff-box is-before">
-                            <span>Alterado</span>
-                            <pre>{stringifyAuditValue(diff.before)}</pre>
-                          </div>
-                        ) : null}
-                        <div className="audit-diff-box is-after">
-                          <span>{diff.before !== undefined ? "Ficou" : "Estado atual"}</span>
-                          <pre>{stringifyAuditValue(diff.after)}</pre>
-                        </div>
-                      </div>
-                    </section>
-                  ))}
-                </div>
-
-                {resolvedDiffs.length > 1 ? (
-                  <button
-                    type="button"
-                    className="audit-card-toggle"
-                    onClick={() =>
-                      setExpandedEntryIds((current) => ({
-                        ...current,
-                        [entry.id]: !current[entry.id]
-                      }))
-                    }
-                  >
-                    {isExpanded
-                      ? "Mostrar menos"
-                      : `Ver mais ${hiddenDiffCount} alteracao${hiddenDiffCount === 1 ? "" : "es"}`}
-                  </button>
-                ) : null}
-              </article>
-            );
-          })}
+                  return (
+                    <Fragment key={row.id}>
+                      <tr className="audit-grid-row" onClick={() => setExpandedRowIds((current) => ({ ...current, [row.id]: !current[row.id] }))}>
+                        <td>{formatAuditDateTime(row.entry.createdAt)}</td>
+                        <td>{row.entry.table}</td>
+                        <td>{row.entry.actionLabel}</td>
+                        <td>{row.field}</td>
+                        <td>
+                          <pre>{stringifyAuditValue(row.before)}</pre>
+                        </td>
+                        <td>
+                          <pre>{stringifyAuditValue(row.after)}</pre>
+                        </td>
+                      </tr>
+                      {isExpanded ? (
+                        <tr className="audit-grid-expanded-row">
+                          <td colSpan={6}>
+                            <div className="audit-grid-expanded-content">
+                              <span>
+                                <strong>Usuario:</strong> {row.entry.authorName || "sem autor"}
+                              </span>
+                              {row.entry.authorRole ? (
+                                <span>
+                                  <strong>Cargo:</strong> {row.entry.authorRole}
+                                </span>
+                              ) : null}
+                              {row.entry.authorEmail ? (
+                                <span>
+                                  <strong>Email:</strong> {row.entry.authorEmail}
+                                </span>
+                              ) : null}
+                              {row.entry.pk ? (
+                                <span>
+                                  <strong>PK:</strong> {row.entry.pk}
+                                </span>
+                              ) : null}
+                              {row.entry.inBatch ? (
+                                <span>
+                                  <strong>Lote:</strong> {row.entry.batchId || "sim"}
+                                </span>
+                              ) : null}
+                              {row.entry.details ? (
+                                <span>
+                                  <strong>Detalhes:</strong> {row.entry.details}
+                                </span>
+                              ) : null}
+                            </div>
+                          </td>
+                        </tr>
+                      ) : null}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          ) : null}
         </div>
 
         <footer className="audit-dashboard-footer">

--- a/components/auth/auth-provider.tsx
+++ b/components/auth/auth-provider.tsx
@@ -8,7 +8,6 @@ import { ROLE_ORDER } from "@/lib/domain/access";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { syncBrowserSessionHint } from "@/lib/supabase/session-hint";
 
-type BrowserSupabase = ReturnType<typeof createSupabaseBrowserClient>;
 type ProfileState = "idle" | "loading" | "ready" | "error";
 
 type AuthContextValue = {
@@ -135,15 +134,12 @@ async function fetchActorWithRetry(accessToken: string) {
 }
 
 export function AuthSessionProvider({ children }: { children: React.ReactNode }) {
-  const clientRef = useRef<BrowserSupabase | null>(null);
-  if (!clientRef.current) {
+  const clientRef = useRef<ReturnType<typeof createSupabaseBrowserClient>>(null);
+  if (typeof window !== "undefined" && !clientRef.current) {
     clientRef.current = createSupabaseBrowserClient();
   }
 
   const supabase = clientRef.current;
-  if (!supabase) {
-    throw new Error("Falha ao inicializar o client do Supabase.");
-  }
 
   const validatedTokenRef = useRef<string | null>(null);
   const actorRef = useRef<CurrentActor | null>(null);
@@ -170,6 +166,13 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
   }, [profileState]);
 
   useEffect(() => {
+    if (!supabase) {
+      setAuthBootstrapped(true);
+      setSessionChecking(false);
+      return;
+    }
+    const currentSupabase = supabase;
+
     let active = true;
 
     function resetAnonymousState() {
@@ -205,7 +208,7 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
           setAuthError(error.message);
           setProfileState("idle");
           syncBrowserSessionHint(null);
-          await supabase.auth.signOut();
+          await currentSupabase.auth.signOut();
           return;
         }
 
@@ -282,7 +285,7 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
           error instanceof ApiClientError &&
           ["UNAUTHENTICATED", "INVALID_SESSION", "PROFILE_NOT_FOUND", "ACCOUNT_NOT_APPROVED"].includes(error.code ?? "")
         ) {
-          await supabase.auth.signOut();
+          await currentSupabase.auth.signOut();
         }
       } finally {
         if (active) {
@@ -294,7 +297,7 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
 
     const {
       data: { subscription }
-    } = supabase.auth.onAuthStateChange((event, session) => {
+    } = currentSupabase.auth.onAuthStateChange((event, session) => {
       void hydrateActor(event, session);
     });
 
@@ -315,6 +318,11 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
   }
 
   async function signIn(params: { email: string; password: string }) {
+    if (!supabase) {
+      setAuthError("Autenticacao indisponivel no ambiente local sem variaveis do Supabase.");
+      return;
+    }
+
     setAuthSubmitting(true);
     setDevModeEnabled(false);
     setAuthError(null);
@@ -337,6 +345,11 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
   }
 
   async function signUp(params: { name: string; email: string; password: string }) {
+    if (!supabase) {
+      setAuthError("Cadastro indisponivel no ambiente local sem variaveis do Supabase.");
+      return;
+    }
+
     setAuthSubmitting(true);
     setDevModeEnabled(false);
     setAuthError(null);
@@ -369,6 +382,11 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
   }
 
   async function signOut() {
+    if (!supabase) {
+      setAuthError("Sessao local sem Supabase para encerrar.");
+      return;
+    }
+
     validatedTokenRef.current = null;
     setAuthError(null);
     setAuthInfo(null);

--- a/components/ui-grid/api.ts
+++ b/components/ui-grid/api.ts
@@ -230,6 +230,8 @@ export async function fetchAuditDashboard(params: {
   requestAuth: RequestAuth;
   page: number;
   pageSize: number;
+  sortBy?: "createdAt" | "table" | "action" | "author";
+  sortDir?: "asc" | "desc";
   autor?: string;
   tabela?: string;
   acao?: string;
@@ -250,6 +252,8 @@ export async function fetchAuditDashboard(params: {
   if (params.dateTo) queryString.set("date_to", params.dateTo);
   if (params.search) queryString.set("search", params.search);
   if (params.searchMode) queryString.set("search_mode", params.searchMode);
+  if (params.sortBy) queryString.set("sort_by", params.sortBy);
+  if (params.sortDir) queryString.set("sort_dir", params.sortDir);
 
   const response = await fetchWithTimeout(`/api/v1/auditoria/dashboard?${queryString.toString()}`, {
     cache: "no-store",

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -22,13 +22,11 @@ async function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit) {
   }
 }
 
-export function createSupabaseBrowserClient(): SupabaseClient<Database> {
+export function createSupabaseBrowserClient(): SupabaseClient<Database> | null {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-  if (!url || !anonKey) {
-    throw new Error("Supabase env vars ausentes no client.");
-  }
+  if (!url || !anonKey) return null;
 
   return createClient<Database>(url, anonKey, {
     global: {


### PR DESCRIPTION
### Motivation

- Provide a tabular, sortable audit log view with per-diff rows to make change inspection and sorting easier.
- Allow server-side sorting via query params and keep client/server in sync for sort state.
- Make Supabase browser client initialization resilient to missing env vars and avoid runtime errors in local/non-browser contexts.

### Description

- API: added `sort_by` and `sort_dir` parsing (`normalizeAuditSortBy`, `normalizeAuditSortDir`) and applied ordering to the `log_alteracoes` query in `app/api/v1/auditoria/dashboard/route.ts`.
- Client API: exposed `sortBy`/`sortDir` params on `fetchAuditDashboard` and included them in the request query string in `components/ui-grid/api.ts`.
- UI: replaced card-based audit list with a paginated, expandable, sortable grid in `components/audit/audit-log-dashboard.tsx`, implemented flattening of diffs into per-field rows, client-side sorting, row expansion and sort indicator/toggle behavior.
- Styles: added grid/table styling and expanded-row/empty states to `app/globals.css` to support the new grid layout and interactions.
- Auth & Supabase client: changed `createSupabaseBrowserClient` to return `null` when env vars are missing, guarded client creation with `typeof window` and made `AuthSessionProvider` resilient to a missing Supabase client by early-returning in effects and surfacing friendly auth error messages for sign-in/sign-up/sign-out operations in `components/auth/auth-provider.tsx` and `lib/supabase/client.ts`.

### Testing

- Ran TypeScript type-check (`tsc --noEmit`) which completed successfully.
- Ran lint checks (`eslint`) which completed successfully.
- Performed a development build (`pnpm build` / app build) to validate bundling and the changes which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1269c83588328acd748b25efeff53)