### PR TITLE
Refatora auth provider com hooks e contextos separados

### DIFF
--- a/components/auth/auth-provider.tsx
+++ b/components/auth/auth-provider.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { createContext, useContext, useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
 import { ApiClientError, fetchCurrentActor } from "@/components/ui-grid/api";
-import type { CurrentActor, Role } from "@/components/ui-grid/types";
+import type { CurrentActor, Role, SessionStatus } from "@/lib/domain/auth-session";
 import { ROLE_ORDER } from "@/lib/domain/access";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { syncBrowserSessionHint } from "@/lib/supabase/session-hint";
 
 type ProfileState = "idle" | "loading" | "ready" | "error";
 
-type AuthContextValue = {
+type SessionState = {
   accessToken: string | null;
   actor: CurrentActor | null;
   authBootstrapped: boolean;
@@ -22,7 +22,10 @@ type AuthContextValue = {
   devRole: Role;
   profileLoading: boolean;
   sessionChecking: boolean;
-  status: "loading" | "signed_out" | "ready" | "profile_error";
+  status: SessionStatus;
+};
+
+type AuthActions = {
   enableDevMode: (role: Role) => void;
   resetFeedback: () => void;
   setAuthError: (value: string | null) => void;
@@ -33,10 +36,11 @@ type AuthContextValue = {
   requestPasswordReset: (email: string) => Promise<void>;
 };
 
-const AuthContext = createContext<AuthContextValue | null>(null);
+const SessionStateContext = createContext<SessionState | null>(null);
+const AuthActionsContext = createContext<AuthActions | null>(null);
 
 const ACTOR_CACHE_KEY = "rn-gestor.current-actor";
-const DEV_MODE_ROLES: Role[] = [...ROLE_ORDER];
+export const DEV_MODE_ROLES: Role[] = [...ROLE_ORDER];
 
 type CachedActorState = {
   actor: CurrentActor;
@@ -134,7 +138,69 @@ async function fetchActorWithRetry(accessToken: string) {
   }
 }
 
-export function AuthSessionProvider({ children }: { children: React.ReactNode }) {
+function useSessionState(params: {
+  actor: CurrentActor | null;
+  accessToken: string | null;
+  authBootstrapped: boolean;
+  authError: string | null;
+  authInfo: string | null;
+  authSubmitting: boolean;
+  canUseDevMode: boolean;
+  devModeEnabled: boolean;
+  devRole: Role;
+  sessionChecking: boolean;
+  profileState: ProfileState;
+}) {
+  const effectiveActor = params.devModeEnabled ? buildDevActor(params.devRole) : params.actor;
+  const effectiveAccessToken = params.devModeEnabled ? null : params.accessToken;
+  const profileLoading = params.profileState === "loading";
+
+  const status: SessionStatus =
+    !params.authBootstrapped ||
+    params.sessionChecking ||
+    (effectiveAccessToken && !effectiveActor && profileLoading)
+      ? "loading"
+      : effectiveActor
+        ? "ready"
+        : effectiveAccessToken && params.profileState === "error"
+          ? "profile_error"
+          : effectiveAccessToken
+            ? "loading"
+            : "signed_out";
+
+  return useMemo(
+    () => ({
+      accessToken: effectiveAccessToken,
+      actor: effectiveActor,
+      authBootstrapped: params.authBootstrapped,
+      authError: params.authError,
+      authInfo: params.authInfo,
+      authSubmitting: params.authSubmitting,
+      canUseDevMode: params.canUseDevMode,
+      devModeEnabled: params.devModeEnabled,
+      devRole: params.devRole,
+      profileLoading,
+      sessionChecking: params.sessionChecking,
+      status
+    }),
+    [
+      effectiveAccessToken,
+      effectiveActor,
+      params.authBootstrapped,
+      params.authError,
+      params.authInfo,
+      params.authSubmitting,
+      params.canUseDevMode,
+      params.devModeEnabled,
+      params.devRole,
+      params.sessionChecking,
+      profileLoading,
+      status
+    ]
+  );
+}
+
+function useActorProfile() {
   const clientRef = useRef<ReturnType<typeof createSupabaseBrowserClient>>(null);
   if (typeof window !== "undefined" && !clientRef.current) {
     clientRef.current = createSupabaseBrowserClient();
@@ -217,8 +283,6 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
         if (!hadActor) {
           setProfileState("error");
         }
-      } finally {
-        if (!active) return;
       }
     }
 
@@ -313,170 +377,222 @@ export function AuthSessionProvider({ children }: { children: React.ReactNode })
     cleanupAuthCallbackUrl();
   }, [authBootstrapped]);
 
-  function resetFeedback() {
-    setAuthError(null);
-    setAuthInfo(null);
-  }
+  return {
+    supabase,
+    validatedTokenRef,
+    actor,
+    setActor,
+    accessToken,
+    setAccessToken,
+    authBootstrapped,
+    authError,
+    authInfo,
+    authSubmitting,
+    canUseDevMode,
+    devModeEnabled,
+    devRole,
+    profileState,
+    sessionChecking,
+    setAuthError,
+    setAuthInfo,
+    setAuthSubmitting,
+    setAuthBootstrapped,
+    setDevModeEnabled,
+    setDevRole,
+    setProfileState,
+    setSessionChecking
+  };
+}
 
-  async function signIn(params: { email: string; password: string }) {
-    if (!supabase) {
-      setAuthError("Autenticacao indisponivel no ambiente local sem variaveis do Supabase.");
-      return;
-    }
+function useAuthActions(state: ReturnType<typeof useActorProfile>): AuthActions {
+  const {
+    supabase,
+    validatedTokenRef,
+    setAuthError,
+    setAuthInfo,
+    setAuthSubmitting,
+    setDevModeEnabled,
+    setActor,
+    setAccessToken,
+    setProfileState,
+    setAuthBootstrapped,
+    setSessionChecking,
+    setDevRole
+  } = state;
 
-    setAuthSubmitting(true);
-    setDevModeEnabled(false);
-    setAuthError(null);
-    setAuthInfo(null);
-
-    try {
-      const { error } = await supabase.auth.signInWithPassword({
-        email: params.email.trim(),
-        password: params.password.trim()
-      });
-
-      if (error) throw error;
-
-      setAuthInfo("Sessao iniciada.");
-    } catch (error) {
-      setAuthError(error instanceof Error ? error.message : "Falha de autenticacao.");
-    } finally {
-      setAuthSubmitting(false);
-    }
-  }
-
-  async function signUp(params: { name: string; email: string; password: string }) {
-    if (!supabase) {
-      setAuthError("Cadastro indisponivel no ambiente local sem variaveis do Supabase.");
-      return;
-    }
-
-    setAuthSubmitting(true);
-    setDevModeEnabled(false);
-    setAuthError(null);
-    setAuthInfo(null);
-
-    try {
-      const { data, error } = await supabase.auth.signUp({
-        email: params.email.trim(),
-        password: params.password.trim(),
-        options: {
-          emailRedirectTo: getCurrentAuthRedirectUrl(),
-          data: {
-            full_name: params.name.trim()
-          }
+  return useMemo(
+    () => ({
+      resetFeedback() {
+        setAuthError(null);
+        setAuthInfo(null);
+      },
+      async signIn(params) {
+        if (!supabase) {
+          setAuthError("Autenticacao indisponivel no ambiente local sem variaveis do Supabase.");
+          return;
         }
-      });
 
-      if (error) throw error;
+        setAuthSubmitting(true);
+        setDevModeEnabled(false);
+        setAuthError(null);
+        setAuthInfo(null);
 
-      if (data.session) {
-        setAuthInfo("Conta criada. Aguarde aprovacao para acessar o sistema.");
-      } else {
-        setAuthInfo("Conta criada. Confirme o email se necessario e aguarde aprovacao para acessar o sistema.");
-      }
-    } catch (error) {
-      setAuthError(error instanceof Error ? error.message : "Falha de autenticacao.");
-    } finally {
-      setAuthSubmitting(false);
-    }
-  }
+        try {
+          const { error } = await supabase.auth.signInWithPassword({
+            email: params.email.trim(),
+            password: params.password.trim()
+          });
 
-  async function signOut() {
-    if (!supabase) {
-      setAuthError("Sessao local sem Supabase para encerrar.");
-      return;
-    }
+          if (error) throw error;
 
-    validatedTokenRef.current = null;
-    setAuthError(null);
-    setAuthInfo(null);
-    setDevModeEnabled(false);
-    setActor(null);
-    setAccessToken(null);
-    clearCachedActor();
-    setProfileState("idle");
-    syncBrowserSessionHint(null);
-    await supabase.auth.signOut();
-  }
+          setAuthInfo("Sessao iniciada.");
+        } catch (error) {
+          setAuthError(error instanceof Error ? error.message : "Falha de autenticacao.");
+        } finally {
+          setAuthSubmitting(false);
+        }
+      },
+      async signUp(params) {
+        if (!supabase) {
+          setAuthError("Cadastro indisponivel no ambiente local sem variaveis do Supabase.");
+          return;
+        }
 
-  function enableDevMode(role: Role) {
-    setDevRole(role);
-    setDevModeEnabled(true);
-    setAuthError(null);
-    setAuthInfo(null);
-    setActor(buildDevActor(role));
-    setAccessToken(null);
-    validatedTokenRef.current = null;
-    clearCachedActor();
-    setAuthBootstrapped(true);
-    setSessionChecking(false);
-    setProfileState("ready");
-  }
+        setAuthSubmitting(true);
+        setDevModeEnabled(false);
+        setAuthError(null);
+        setAuthInfo(null);
 
-  async function requestPasswordReset(email: string) {
-    const client = createSupabaseBrowserClient();
-    if (!client) throw new Error("Auth indisponivel no navegador.");
-    const redirectTo = getCurrentAuthRedirectUrl();
-    const { error } = await client.auth.resetPasswordForEmail(email, { redirectTo });
-    if (error) throw new Error(error.message);
-    setAuthInfo("Enviamos um email com o link de recuperacao.");
-  }
+        try {
+          const { data, error } = await supabase.auth.signUp({
+            email: params.email.trim(),
+            password: params.password.trim(),
+            options: {
+              emailRedirectTo: getCurrentAuthRedirectUrl(),
+              data: {
+                full_name: params.name.trim()
+              }
+            }
+          });
 
-  const effectiveActor = devModeEnabled ? buildDevActor(devRole) : actor;
-  const effectiveAccessToken = devModeEnabled ? null : accessToken;
-  const profileLoading = profileState === "loading";
+          if (error) throw error;
 
-  const status =
-    !authBootstrapped || sessionChecking || (effectiveAccessToken && !effectiveActor && profileLoading)
-      ? "loading"
-      : effectiveActor
-        ? "ready"
-        : effectiveAccessToken && profileState === "error"
-          ? "profile_error"
-          : effectiveAccessToken
-            ? "loading"
-            : "signed_out";
+          if (data.session) {
+            setAuthInfo("Conta criada. Aguarde aprovacao para acessar o sistema.");
+          } else {
+            setAuthInfo("Conta criada. Confirme o email se necessario e aguarde aprovacao para acessar o sistema.");
+          }
+        } catch (error) {
+          setAuthError(error instanceof Error ? error.message : "Falha de autenticacao.");
+        } finally {
+          setAuthSubmitting(false);
+        }
+      },
+      async signOut() {
+        if (!supabase) {
+          setAuthError("Sessao local sem Supabase para encerrar.");
+          return;
+        }
 
-  return (
-    <AuthContext.Provider
-      value={{
-        accessToken: effectiveAccessToken,
-        actor: effectiveActor,
-        authBootstrapped,
-        authError,
-        authInfo,
-        authSubmitting,
-        canUseDevMode,
-        devModeEnabled,
-        devRole,
-        profileLoading,
-        sessionChecking,
-        status,
-        enableDevMode,
-        resetFeedback,
-        setAuthError,
-        setDevRole,
-        signIn,
-        signOut,
-        signUp,
-        requestPasswordReset
-      }}
-    >
-      {children}
-    </AuthContext.Provider>
+        validatedTokenRef.current = null;
+        setAuthError(null);
+        setAuthInfo(null);
+        setDevModeEnabled(false);
+        setActor(null);
+        setAccessToken(null);
+        clearCachedActor();
+        setProfileState("idle");
+        syncBrowserSessionHint(null);
+        await supabase.auth.signOut();
+      },
+      enableDevMode(role) {
+        setDevRole(role);
+        setDevModeEnabled(true);
+        setAuthError(null);
+        setAuthInfo(null);
+        setActor(buildDevActor(role));
+        setAccessToken(null);
+        validatedTokenRef.current = null;
+        clearCachedActor();
+        setAuthBootstrapped(true);
+        setSessionChecking(false);
+        setProfileState("ready");
+      },
+      async requestPasswordReset(email) {
+        const client = createSupabaseBrowserClient();
+        if (!client) throw new Error("Auth indisponivel no navegador.");
+        const redirectTo = getCurrentAuthRedirectUrl();
+        const { error } = await client.auth.resetPasswordForEmail(email, { redirectTo });
+        if (error) throw new Error(error.message);
+        setAuthInfo("Enviamos um email com o link de recuperacao.");
+      },
+      setAuthError,
+      setDevRole
+    }),
+    [
+      supabase,
+      validatedTokenRef,
+      setAccessToken,
+      setActor,
+      setAuthBootstrapped,
+      setAuthError,
+      setAuthInfo,
+      setAuthSubmitting,
+      setDevModeEnabled,
+      setDevRole,
+      setProfileState,
+      setSessionChecking
+    ]
   );
 }
 
-export function useAuthSession() {
-  const context = useContext(AuthContext);
+export function AuthSessionProvider({ children }: { children: React.ReactNode }) {
+  const actorProfile = useActorProfile();
+  const sessionState = useSessionState({
+    actor: actorProfile.actor,
+    accessToken: actorProfile.accessToken,
+    authBootstrapped: actorProfile.authBootstrapped,
+    authError: actorProfile.authError,
+    authInfo: actorProfile.authInfo,
+    authSubmitting: actorProfile.authSubmitting,
+    canUseDevMode: actorProfile.canUseDevMode,
+    devModeEnabled: actorProfile.devModeEnabled,
+    devRole: actorProfile.devRole,
+    sessionChecking: actorProfile.sessionChecking,
+    profileState: actorProfile.profileState
+  });
+  const actions = useAuthActions(actorProfile);
+
+  return (
+    <SessionStateContext.Provider value={sessionState}>
+      <AuthActionsContext.Provider value={actions}>{children}</AuthActionsContext.Provider>
+    </SessionStateContext.Provider>
+  );
+}
+
+export function useAuthSessionState() {
+  const context = useContext(SessionStateContext);
 
   if (!context) {
-    throw new Error("useAuthSession deve ser usado dentro de AuthSessionProvider.");
+    throw new Error("useAuthSessionState deve ser usado dentro de AuthSessionProvider.");
   }
 
   return context;
 }
 
-export { DEV_MODE_ROLES };
-// (moved) requestPasswordReset agora fica dentro do AuthSessionProvider
+export function useAuthActionsContext() {
+  const context = useContext(AuthActionsContext);
+
+  if (!context) {
+    throw new Error("useAuthActionsContext deve ser usado dentro de AuthSessionProvider.");
+  }
+
+  return context;
+}
+
+export function useAuthSession() {
+  return {
+    ...useAuthSessionState(),
+    ...useAuthActionsContext()
+  };
+}

--- a/components/auth/login-screen.tsx
+++ b/components/auth/login-screen.tsx
@@ -2,9 +2,13 @@
 
 import { FormEvent, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { DEV_MODE_ROLES, useAuthSession } from "@/components/auth/auth-provider";
+import {
+  DEV_MODE_ROLES,
+  useAuthActionsContext,
+  useAuthSessionState
+} from "@/components/auth/auth-provider";
 import { AuthStatusCard } from "@/components/auth/auth-status-card";
-import type { Role } from "@/components/ui-grid/types";
+import type { Role } from "@/lib/domain/auth-session";
 import styles from "@/components/auth/auth.module.css";
 
 type AuthMode = "login" | "signup";
@@ -25,23 +29,9 @@ export function LoginScreen() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const nextPath = getSafeNextPath(searchParams.get("next"));
-  const {
-    authError,
-    authInfo,
-    authSubmitting,
-    canUseDevMode,
-    devRole,
-    enableDevMode,
-    profileLoading,
-    resetFeedback,
-    setAuthError,
-    setDevRole,
-    signIn,
-    signOut,
-    signUp,
-    requestPasswordReset,
-    status
-  } = useAuthSession();
+  const { authError, authInfo, authSubmitting, canUseDevMode, devRole, profileLoading, status } = useAuthSessionState();
+  const { enableDevMode, resetFeedback, requestPasswordReset, setAuthError, setDevRole, signIn, signOut, signUp } =
+    useAuthActionsContext();
 
   const [authMode, setAuthMode] = useState<AuthMode>("login");
   const [formState, setFormState] = useState(initialFormState);

--- a/components/ui-grid/authenticated-workspace.tsx
+++ b/components/ui-grid/authenticated-workspace.tsx
@@ -4,10 +4,11 @@ import { useEffect, type ReactElement } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { AuthStatusCard } from "@/components/auth/auth-status-card";
 import { UserAdminWorkspace } from "@/components/admin/user-admin-workspace";
-import { useAuthSession } from "@/components/auth/auth-provider";
+import { useAuthActionsContext, useAuthSessionState } from "@/components/auth/auth-provider";
 import { FileManagerWorkspace } from "@/components/files/file-manager-workspace";
 import { PersonalWorkspace } from "@/components/profile/personal-workspace";
 import { HolisticSheet, type AuditDashboardFilterDefaults } from "@/components/ui-grid/holistic-sheet";
+import type { CurrentActor, Role } from "@/lib/domain/auth-session";
 import type { SheetKey } from "@/components/ui-grid/types";
 import styles from "@/components/ui-grid/ui-grid.module.css";
 
@@ -20,10 +21,10 @@ type AuthenticatedWorkspaceProps = {
 };
 
 type WorkspaceSharedProps = {
-  actor: NonNullable<ReturnType<typeof useAuthSession>["actor"]>;
-  accessToken: ReturnType<typeof useAuthSession>["accessToken"];
-  devRole?: ReturnType<typeof useAuthSession>["devRole"];
-  onSignOut: ReturnType<typeof useAuthSession>["signOut"];
+  actor: CurrentActor;
+  accessToken: string | null;
+  devRole?: Role;
+  onSignOut: () => Promise<void>;
   initialAuditFilters?: AuditDashboardFilterDefaults;
   initialSheetKey?: SheetKey;
 };
@@ -82,7 +83,8 @@ export function AuthenticatedWorkspace({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { accessToken, actor, authError, devModeEnabled, devRole, signOut, status } = useAuthSession();
+  const { accessToken, actor, authError, devModeEnabled, devRole, status } = useAuthSessionState();
+  const { signOut } = useAuthActionsContext();
 
   useEffect(() => {
     if (status !== "signed_out") return;

--- a/components/ui-grid/types.ts
+++ b/components/ui-grid/types.ts
@@ -1,23 +1,9 @@
-import type { AppRole } from "@/lib/domain/access";
+export type { CurrentActor, RequestAuth, Role } from "@/lib/domain/auth-session";
+import type { Role } from "@/lib/domain/auth-session";
 import type { GridTableName } from "@/lib/domain/grid-policy";
 
 export type SheetKey = GridTableName;
 
-export type Role = AppRole;
-
-export type CurrentActor = {
-  authUserId: string | null;
-  role: Role;
-  status: string;
-  userId: string | null;
-  userName: string;
-  userEmail: string | null;
-};
-
-export type RequestAuth = {
-  accessToken: string | null;
-  devRole?: Role | null;
-};
 
 export type SortRule = {
   column: string;

--- a/lib/domain/auth-session.ts
+++ b/lib/domain/auth-session.ts
@@ -1,0 +1,19 @@
+import type { AppRole } from "@/lib/domain/access";
+
+export type Role = AppRole;
+
+export type CurrentActor = {
+  authUserId: string | null;
+  role: Role;
+  status: string;
+  userId: string | null;
+  userName: string;
+  userEmail: string | null;
+};
+
+export type SessionStatus = "loading" | "signed_out" | "ready" | "profile_error";
+
+export type RequestAuth = {
+  accessToken: string | null;
+  devRole?: Role | null;
+};


### PR DESCRIPTION
### Motivation

- Reduzir rerenders e separar responsabilidades do provedor de autenticação para melhorar performance e testabilidade.
- Extrair tipos de sessão/papéis para um módulo de domínio reutilizável e independente da camada de UI Grid.

### Description

- Extraí a lógica do `AuthSessionProvider` em três hooks: `useActorProfile` (hidratação/sincronização de sessão e perfil), `useSessionState` (deriva o estado efetivo da sessão) e `useAuthActions` (ações e feedback de autenticação).
- Substituí o contexto único por dois contextos menores: `SessionStateContext` (estado estável) e `AuthActionsContext` (ações), mantendo a compatibilidade através de `useAuthSession` que compõe ambos.
- Atualizei consumidores para assinarem apenas o necessário: `components/auth/login-screen.tsx` agora usa `useAuthSessionState` + `useAuthActionsContext`, e `components/ui-grid/authenticated-workspace.tsx` foi adaptado no mesmo padrão.
- Centralizei os tipos de autenticação em `lib/domain/auth-session.ts` e passei `components/ui-grid/types.ts` a reexportar/consumir esses tipos para manter compatibilidade com imports existentes.

### Testing

- Executado `npm run lint`, que concluiu com sucesso mostrando somente warnings preexistentes no projeto.
- Executado `npx tsc --noEmit`, que apontou erros de tipos em `components/ui-grid/holistic-sheet.tsx` que já existiam e não estão relacionados a este refactor; portanto o typecheck terminou com falha por problemas pré-existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8de40d5d88328b0a35b876c166d67)