### PR TITLE
refactor(core): introduce lib/core namespace and migrate shared types/utilities

### DIFF
--- a/app/api/v1/auditoria/dashboard/route.ts
+++ b/app/api/v1/auditoria/dashboard/route.ts
@@ -3,10 +3,7 @@ import { executeAuthorizedApi } from "@/lib/api/execute";
 import { apiOk } from "@/lib/api/response";
 import { ApiHttpError } from "@/lib/api/errors";
 import { parsePagination } from "@/lib/api/request";
-
-function endOfDayIso(date: string) {
-  return `${date}T23:59:59.999`;
-}
+import { endOfDayIso, normalizeTextSearch } from "@/lib/core/formatters";
 
 function normalizeAuditSearchTerm(value: string) {
   return value.replace(/[,%()]/g, " ").replace(/\s+/g, " ").trim();
@@ -39,22 +36,6 @@ function normalizeAuditSortDir(value: string) {
   return value === "asc" ? "asc" : "desc";
 }
 
-function normalizeSearchText(value: unknown) {
-  if (value == null) return "";
-
-  const text =
-    typeof value === "string"
-      ? value
-      : typeof value === "number" || typeof value === "boolean"
-        ? String(value)
-        : JSON.stringify(value);
-
-  return text
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
-    .toLowerCase();
-}
-
 function buildAuditRowSearchText(
   row: {
     acao: string | null;
@@ -70,7 +51,7 @@ function buildAuditRowSearchText(
   },
   actionLabel: string
 ) {
-  return normalizeSearchText(
+  return normalizeTextSearch(
     [
       actionLabel,
       row.acao,
@@ -174,7 +155,7 @@ export async function GET(req: NextRequest) {
     const tables = Array.from(new Set((tableRows ?? []).map((row) => row.tabela).filter(Boolean))).sort((a, b) =>
       a.localeCompare(b, "pt-BR")
     );
-    const normalizedSearch = normalizeSearchText(search);
+    const normalizedSearch = normalizeTextSearch(search);
     const filteredRows =
       normalizedSearch && rows
         ? rows.filter((row) =>

--- a/components/admin/api.ts
+++ b/components/admin/api.ts
@@ -1,14 +1,6 @@
 import { ApiClientError, buildRequestHeaders } from "@/components/ui-grid/api";
 import type { RequestAuth } from "@/components/ui-grid/types";
-
-type ApiEnvelope<T> = {
-  data: T;
-  error?: {
-    code: string;
-    message: string;
-    details?: unknown;
-  };
-};
+import type { ApiEnvelope } from "@/lib/core/types";
 
 const ADMIN_API_TIMEOUT_MS = 15_000;
 

--- a/components/erp-console.tsx
+++ b/components/erp-console.tsx
@@ -5,8 +5,7 @@ import { Button } from "@/components/atoms/button";
 import { Card } from "@/components/atoms/card";
 import { Input } from "@/components/atoms/input";
 import { buildRequestHeaders } from "@/components/ui-grid/api";
-
-type LookupItem = { code: string; name: string };
+import type { ApiEnvelope } from "@/lib/core/types";
 type Modelo = { id: string; modelo: string };
 
 type Carro = {
@@ -37,19 +36,16 @@ type Audit = {
   detalhes: string | null;
 };
 
-type ApiResponse<T> = { data: T; meta?: { total?: number }; error?: { message: string } };
-
-type LookupsPayload = {
-  sale_statuses: LookupItem[];
-  announcement_statuses: LookupItem[];
-  locations: LookupItem[];
-};
+type LookupsPayload = Pick<
+  import("@/lib/core/types").LookupsPayload,
+  "sale_statuses" | "announcement_statuses" | "locations"
+>;
 
 const defaultHeaders = buildRequestHeaders({ accessToken: null, devRole: "ADMINISTRADOR" });
 
 async function getJson<T>(url: string): Promise<T> {
   const response = await fetch(url, { cache: "no-store", headers: defaultHeaders });
-  const json = (await response.json()) as ApiResponse<T>;
+  const json = (await response.json()) as ApiEnvelope<T>;
   if (!response.ok || json.error) throw new Error(json.error?.message ?? "Falha na requisicao");
   return json.data;
 }

--- a/components/files/api.ts
+++ b/components/files/api.ts
@@ -1,15 +1,7 @@
 import { ApiClientError, buildAuthHeaders } from "@/components/ui-grid/api";
 import type { RequestAuth } from "@/components/ui-grid/types";
 import type { FileFolderDetail, FileFolderSummary } from "@/components/files/types";
-
-type ApiEnvelope<T> = {
-  data: T;
-  error?: {
-    code: string;
-    message: string;
-    details?: unknown;
-  };
-};
+import type { ApiEnvelope } from "@/lib/core/types";
 
 const DEFAULT_API_REQUEST_TIMEOUT_MS = 30_000;
 const FILE_UPLOAD_REQUEST_TIMEOUT_MS = 180_000;

--- a/components/ui-grid/api.ts
+++ b/components/ui-grid/api.ts
@@ -9,15 +9,7 @@ import type {
   SheetKey,
   SortRule
 } from "@/components/ui-grid/types";
-
-type ApiEnvelope<T> = {
-  data: T;
-  error?: {
-    code: string;
-    message: string;
-    details?: unknown;
-  };
-};
+import type { ApiEnvelope } from "@/lib/core/types";
 
 export type PlateLookupFipe = {
   codigo_fipe: string | null;

--- a/components/ui-grid/types.ts
+++ b/components/ui-grid/types.ts
@@ -1,4 +1,5 @@
 export type { CurrentActor, RequestAuth, Role } from "@/lib/domain/auth-session";
+export type { LookupItem, LookupsPayload } from "@/lib/core/types";
 import type { Role } from "@/lib/domain/auth-session";
 import type { GridTableName } from "@/lib/domain/grid-policy";
 
@@ -32,20 +33,6 @@ export type TableInsightSummary = {
 
 export type GridInsightsSummaryPayload = {
   byTable: Partial<Record<SheetKey, TableInsightSummary>>;
-};
-
-export type LookupItem = {
-  code: string;
-  name: string;
-};
-
-export type LookupsPayload = {
-  user_roles: LookupItem[];
-  user_statuses: LookupItem[];
-  sale_statuses: LookupItem[];
-  announcement_statuses: LookupItem[];
-  locations: LookupItem[];
-  vehicle_states: LookupItem[];
 };
 
 export type SheetConfig = {

--- a/lib/api/lookups.ts
+++ b/lib/api/lookups.ts
@@ -3,23 +3,10 @@ import type { ActorContext } from "@/lib/api/auth";
 import { ApiHttpError } from "@/lib/api/errors";
 import { hasRequiredRole, type AppRole } from "@/lib/domain/access";
 import type { Database } from "@/lib/supabase/database.types";
-
-type LookupRow = {
-  code: string;
-  name: string;
-};
-
-type LookupPayload = {
-  user_roles: LookupRow[];
-  user_statuses: LookupRow[];
-  sale_statuses: LookupRow[];
-  announcement_statuses: LookupRow[];
-  locations: LookupRow[];
-  vehicle_states: LookupRow[];
-};
+import { EMPTY_LOOKUPS, type LookupItem, type LookupsPayload } from "@/lib/core/types";
 
 type LookupSpec = {
-  key: keyof LookupPayload;
+  key: keyof LookupsPayload;
   table:
     | "lookup_announcement_statuses"
     | "lookup_locations"
@@ -39,19 +26,10 @@ const LOOKUP_SPECS: LookupSpec[] = [
   { key: "user_statuses", table: "lookup_user_statuses", minRole: "ADMINISTRADOR" }
 ];
 
-const EMPTY_LOOKUPS: LookupPayload = {
-  user_roles: [],
-  user_statuses: [],
-  sale_statuses: [],
-  announcement_statuses: [],
-  locations: [],
-  vehicle_states: []
-};
-
 async function fetchActiveLookupTable(
   supabase: SupabaseClient<Database>,
   table: LookupSpec["table"]
-): Promise<LookupRow[]> {
+): Promise<LookupItem[]> {
   const { data, error } = await supabase.from(table).select("code, name").eq("is_active", true).order("sort_order");
 
   if (error) {
@@ -67,11 +45,11 @@ async function fetchActiveLookupTable(
 export async function fetchLookupsForActor(params: {
   actor: ActorContext;
   supabase: SupabaseClient<Database>;
-}): Promise<LookupPayload> {
+}): Promise<LookupsPayload> {
   const entries = await Promise.all(
     LOOKUP_SPECS.map(async (spec) => {
       if (!hasRequiredRole(params.actor.role, spec.minRole)) {
-        return [spec.key, [] as LookupRow[]] as const;
+        return [spec.key, [] as LookupItem[]] as const;
       }
 
       const rows = await fetchActiveLookupTable(params.supabase, spec.table);
@@ -79,7 +57,7 @@ export async function fetchLookupsForActor(params: {
     })
   );
 
-  return entries.reduce<LookupPayload>((acc, [key, rows]) => {
+  return entries.reduce<LookupsPayload>((acc, [key, rows]) => {
     acc[key] = rows;
     return acc;
   }, { ...EMPTY_LOOKUPS });

--- a/lib/api/request.ts
+++ b/lib/api/request.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from "node:crypto";
 import type { NextRequest } from "next/server";
+import { toPaginationWindow } from "@/lib/core/mappers";
+import { clampPage, clampPageSize } from "@/lib/core/guards";
 
 export function getRequestId(req: NextRequest): string {
   return req.headers.get("x-request-id") ?? randomUUID();
 }
 
 export function parsePagination(req: NextRequest) {
-  const page = Math.max(1, Number(req.nextUrl.searchParams.get("page") ?? 1));
-  const pageSize = Math.min(100, Math.max(1, Number(req.nextUrl.searchParams.get("page_size") ?? 20)));
-  const from = (page - 1) * pageSize;
-  const to = from + pageSize - 1;
+  const page = clampPage(Number(req.nextUrl.searchParams.get("page") ?? 1));
+  const pageSize = clampPageSize(Number(req.nextUrl.searchParams.get("page_size") ?? 20), { maximum: 100, fallback: 20 });
 
-  return { page, pageSize, from, to };
+  return toPaginationWindow(page, pageSize);
 }

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,13 +1,7 @@
 import { NextResponse } from "next/server";
+import type { ApiSuccessMeta } from "@/lib/core/types";
 
-type SuccessMeta = {
-  request_id: string;
-  page?: number;
-  page_size?: number;
-  total?: number;
-};
-
-export function apiOk<T>(data: T, meta: SuccessMeta) {
+export function apiOk<T>(data: T, meta: ApiSuccessMeta) {
   return NextResponse.json({ data, meta });
 }
 

--- a/lib/core/formatters/date.ts
+++ b/lib/core/formatters/date.ts
@@ -1,0 +1,3 @@
+export function endOfDayIso(date: string) {
+  return `${date}T23:59:59.999`;
+}

--- a/lib/core/formatters/index.ts
+++ b/lib/core/formatters/index.ts
@@ -1,0 +1,2 @@
+export * from "@/lib/core/formatters/date";
+export * from "@/lib/core/formatters/text";

--- a/lib/core/formatters/text.ts
+++ b/lib/core/formatters/text.ts
@@ -1,0 +1,15 @@
+export function normalizeTextSearch(value: unknown) {
+  if (value == null) return "";
+
+  const text =
+    typeof value === "string"
+      ? value
+      : typeof value === "number" || typeof value === "boolean"
+        ? String(value)
+        : JSON.stringify(value);
+
+  return text
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase();
+}

--- a/lib/core/guards/index.ts
+++ b/lib/core/guards/index.ts
@@ -1,0 +1,1 @@
+export * from "@/lib/core/guards/pagination";

--- a/lib/core/guards/pagination.ts
+++ b/lib/core/guards/pagination.ts
@@ -1,0 +1,14 @@
+export function clampPage(value: number, minimum = 1) {
+  if (!Number.isFinite(value)) return minimum;
+  return Math.max(minimum, Math.floor(value));
+}
+
+export function clampPageSize(value: number, options?: { minimum?: number; maximum?: number; fallback?: number }) {
+  const minimum = options?.minimum ?? 1;
+  const maximum = options?.maximum ?? 100;
+  const fallback = options?.fallback ?? 20;
+
+  if (!Number.isFinite(value)) return fallback;
+
+  return Math.min(maximum, Math.max(minimum, Math.floor(value)));
+}

--- a/lib/core/mappers/index.ts
+++ b/lib/core/mappers/index.ts
@@ -1,0 +1,1 @@
+export * from "@/lib/core/mappers/pagination";

--- a/lib/core/mappers/pagination.ts
+++ b/lib/core/mappers/pagination.ts
@@ -1,0 +1,8 @@
+import type { PaginationWindow } from "@/lib/core/types/pagination";
+
+export function toPaginationWindow(page: number, pageSize: number): PaginationWindow {
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  return { page, pageSize, from, to };
+}

--- a/lib/core/types/api.ts
+++ b/lib/core/types/api.ts
@@ -1,0 +1,13 @@
+import type { ApiSuccessMeta } from "@/lib/core/types/pagination";
+
+export type ApiErrorPayload = {
+  code: string;
+  message: string;
+  details?: unknown;
+};
+
+export type ApiEnvelope<T> = {
+  data: T;
+  meta?: ApiSuccessMeta;
+  error?: ApiErrorPayload;
+};

--- a/lib/core/types/index.ts
+++ b/lib/core/types/index.ts
@@ -1,0 +1,3 @@
+export * from "@/lib/core/types/api";
+export * from "@/lib/core/types/lookups";
+export * from "@/lib/core/types/pagination";

--- a/lib/core/types/lookups.ts
+++ b/lib/core/types/lookups.ts
@@ -1,0 +1,22 @@
+export type LookupItem = {
+  code: string;
+  name: string;
+};
+
+export type LookupsPayload = {
+  user_roles: LookupItem[];
+  user_statuses: LookupItem[];
+  sale_statuses: LookupItem[];
+  announcement_statuses: LookupItem[];
+  locations: LookupItem[];
+  vehicle_states: LookupItem[];
+};
+
+export const EMPTY_LOOKUPS: LookupsPayload = {
+  user_roles: [],
+  user_statuses: [],
+  sale_statuses: [],
+  announcement_statuses: [],
+  locations: [],
+  vehicle_states: []
+};

--- a/lib/core/types/pagination.ts
+++ b/lib/core/types/pagination.ts
@@ -1,0 +1,20 @@
+export type PaginationWindow = {
+  page: number;
+  pageSize: number;
+  from: number;
+  to: number;
+};
+
+export type PaginationMeta = {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+};
+
+export type ApiSuccessMeta = {
+  request_id: string;
+  page?: number;
+  page_size?: number;
+  total?: number;
+};


### PR DESCRIPTION
### Motivation

- Reduce duplication by centralizing repeated types like `LookupItem`, common API envelopes and pagination/meta contracts under a single `lib/core` namespace.
- Extract pure, framework-agnostic helpers (pagination clamping/mappers, text normalizer, date helper) so server and client code can reuse them without React/Next dependencies.
- Allow an incremental migration of imports per feature to avoid a risky big‑bang refactor.

### Description

- Added `lib/core/` with submodules `types`, `mappers`, `formatters` and `guards` and exported indexes for easy consumption (e.g. `lib/core/types`, `lib/core/mappers`).
- Moved shared types into `lib/core/types`: `LookupItem`, `LookupsPayload`, `EMPTY_LOOKUPS`, `ApiEnvelope`/`ApiSuccessMeta`, and pagination types like `PaginationWindow`.
- Implemented reusable pure utilities: pagination clamps (`clampPage`, `clampPageSize`) in `lib/core/guards`, pagination mapper `toPaginationWindow` in `lib/core/mappers`, text normalization `normalizeTextSearch` and `endOfDayIso` in `lib/core/formatters`.
- Incrementally updated imports in affected features to consume the new core helpers, including `lib/api/lookups.ts`, `lib/api/request.ts`, `lib/api/response.ts`, `components/*` consumers (`ui-grid`, `admin`, `files`, `erp-console`) and the audit dashboard route to use shared formatters.

### Testing

- Ran `npx tsc --noEmit`; typecheck failed with pre-existing unresolved symbols in `components/ui-grid/holistic-sheet.tsx` (e.g. `buildOptionLabelMap`, `compareNullableNumbersAsc`, `isDateFilterLiteral`, `PRINT_SCOPE_OPTIONS`), which are unrelated to this refactor and caused the command to exit non-zero.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8df8e9ef48328b01da2dcc8f5979d)