### PR TITLE
Refactor files workspace: extract upload flow hook and domain utilities

### DIFF
--- a/components/files/__tests__/file-order.test.ts
+++ b/components/files/__tests__/file-order.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { reorderFiles } from "../file-order";
+import type { FileItem } from "../types";
+
+const file = (id: string, sortOrder: number): FileItem => ({
+  id,
+  folderId: "folder",
+  fileName: `${id}.txt`,
+  mimeType: "text/plain",
+  sizeBytes: 1,
+  sortOrder,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+  previewUrl: null,
+  downloadUrl: null,
+  isMissing: false,
+});
+
+describe("file-order domain", () => {
+  it("moves source before target and reindexes sortOrder", () => {
+    const result = reorderFiles(
+      [file("a", 0), file("b", 1), file("c", 2)],
+      "c",
+      "a",
+    );
+
+    expect(result.map((entry) => entry.id)).toEqual(["c", "a", "b"]);
+    expect(result.map((entry) => entry.sortOrder)).toEqual([0, 1, 2]);
+  });
+
+  it("returns same reference for invalid reorder", () => {
+    const files = [file("a", 0), file("b", 1)];
+    const result = reorderFiles(files, "x", "b");
+
+    expect(result).toBe(files);
+  });
+});

--- a/components/files/__tests__/folder-tree.test.ts
+++ b/components/files/__tests__/folder-tree.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { buildFolderTree, flattenFolderOptions } from "../folder-tree";
+import type { FileFolderSummary } from "../types";
+
+const folder = (
+  id: string,
+  name: string,
+  parentFolderId: string | null = null,
+): FileFolderSummary => ({
+  id,
+  name,
+  slug: id,
+  description: null,
+  parentFolderId,
+  fileCount: 0,
+  childFolderCount: 0,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+});
+
+describe("folder-tree domain", () => {
+  it("builds and sorts tree recursively", () => {
+    const tree = buildFolderTree([
+      folder("3", "Zulu"),
+      folder("1", "Alpha"),
+      folder("1-2", "Filha B", "1"),
+      folder("1-1", "Filha A", "1"),
+    ]);
+
+    expect(tree.map((node) => node.id)).toEqual(["1", "3"]);
+    expect(tree[0]?.children.map((node) => node.id)).toEqual(["1-1", "1-2"]);
+  });
+
+  it("flattens options with indentation", () => {
+    const options = flattenFolderOptions(
+      buildFolderTree([folder("1", "Raiz"), folder("1-1", "Filha", "1")]),
+    );
+
+    expect(options).toEqual([
+      { id: "1", label: "Raiz" },
+      { id: "1-1", label: "  Filha" },
+    ]);
+  });
+});

--- a/components/files/file-manager-workspace.tsx
+++ b/components/files/file-manager-workspace.tsx
@@ -23,8 +23,6 @@ import {
   renameFolderFile,
   reorderFolderFiles,
   updateFileFolder,
-  prepareFolderUploads,
-  finalizeFolderUploads,
 } from "@/components/files/api";
 
 import type {
@@ -35,6 +33,12 @@ import type {
 
 import type { CurrentActor, Role } from "@/components/ui-grid/types";
 
+import { reorderFiles } from "@/components/files/file-order";
+import {
+  buildFolderTree,
+  flattenFolderOptions,
+  type FolderTreeNode,
+} from "@/components/files/folder-tree";
 import { useFileManagerQueryState } from "@/components/files/hooks/use-file-manager-query-state";
 import { useFileSelection } from "@/components/files/hooks/use-file-selection";
 import { useFileUploadFlow } from "@/components/files/hooks/use-file-upload-flow";
@@ -49,7 +53,6 @@ import {
   MAX_FILE_UPLOAD_BATCH_BYTES,
   MAX_FILE_UPLOAD_COUNT,
   type FilePreviewKind,
-  isPreviewableFile,
 } from "@/lib/files/shared";
 
 type FileManagerWorkspaceProps = {
@@ -62,56 +65,13 @@ type FileManagerWorkspaceProps = {
   onSignOut: () => void | Promise<void>;
 };
 
-type PendingUploadStatus =
-  | "queued"
-  | "uploading"
-  | "failed"
-  | "canceled"
-  | "completed";
-
-type PendingUploadItem = {
-  id: string;
-
-  batchId: string;
-
-  folderId: string;
-
-  fileName: string;
-
-  file: File;
-
-  mimeType: string;
-
-  sizeBytes: number;
-
-  previewUrl: string | null;
-
-  createdAt: string;
-
-  status: PendingUploadStatus;
-
-  attempts: number;
-
-  errorMessage?: string | null;
-};
-
 type CreatePanelState = null | {
   parentFolderId: string | null;
-};
-
-type FolderTreeNode = FileFolderSummary & {
-  children: FolderTreeNode[];
 };
 
 type ViewMode = "compact" | "medium" | "large";
 
 type MobileFilesSection = "browser" | "preview" | "manage";
-
-const BASE_UPLOAD_RETRY_DELAY_MS = 1_500;
-
-const MAX_UPLOAD_RETRY_DELAY_MS = 30_000;
-
-const MAX_UPLOAD_ATTEMPTS = 5;
 
 function formatDateTime(value: string) {
   return new Date(value).toLocaleString("pt-BR");
@@ -137,83 +97,6 @@ function isWithinDateRange(value: string, startDate: string, endDate: string) {
   return true;
 }
 
-function reorderFiles(files: FileItem[], draggedId: string, targetId: string) {
-  const sourceIndex = files.findIndex((file) => file.id === draggedId);
-
-  const targetIndex = files.findIndex((file) => file.id === targetId);
-
-  if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) {
-    return files;
-  }
-
-  const next = [...files];
-
-  const [moved] = next.splice(sourceIndex, 1);
-
-  next.splice(targetIndex, 0, moved);
-
-  return next.map((file, index) => ({
-    ...file,
-
-    sortOrder: index,
-  }));
-}
-
-function buildFolderTree(folders: FileFolderSummary[]) {
-  const nodeById = new Map<string, FolderTreeNode>();
-
-  for (const folder of folders) {
-    nodeById.set(folder.id, {
-      ...folder,
-
-      children: [],
-    });
-  }
-
-  const roots: FolderTreeNode[] = [];
-
-  for (const folder of folders) {
-    const node = nodeById.get(folder.id);
-
-    if (!node) continue;
-
-    if (folder.parentFolderId && nodeById.has(folder.parentFolderId)) {
-      nodeById.get(folder.parentFolderId)?.children.push(node);
-
-      continue;
-    }
-
-    roots.push(node);
-  }
-
-  function sortNodes(nodes: FolderTreeNode[]) {
-    nodes.sort((left, right) => left.name.localeCompare(right.name, "pt-BR"));
-
-    for (const node of nodes) {
-      sortNodes(node.children);
-    }
-  }
-
-  sortNodes(roots);
-
-  return roots;
-}
-
-function flattenFolderOptions(
-  nodes: FolderTreeNode[],
-  level = 0,
-): Array<{ id: string; label: string }> {
-  return nodes.flatMap((node) => [
-    {
-      id: node.id,
-
-      label: `${"  ".repeat(level)}${node.name}`,
-    },
-
-    ...flattenFolderOptions(node.children, level + 1),
-  ]);
-}
-
 function getPreviewLabel(kind: FilePreviewKind) {
   switch (kind) {
     case "image":
@@ -234,52 +117,6 @@ function getPreviewLabel(kind: FilePreviewKind) {
     default:
       return "ARQ";
   }
-}
-
-function createLocalId() {
-  if (
-    typeof crypto !== "undefined" &&
-    typeof crypto.randomUUID === "function"
-  ) {
-    return crypto.randomUUID();
-  }
-
-  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
-}
-
-function splitFilesIntoUploadBatches(files: File[]) {
-  const batches: File[][] = [];
-
-  let currentBatch: File[] = [];
-
-  let currentBatchBytes = 0;
-
-  for (const file of files) {
-    const nextBatchWouldOverflowCount =
-      currentBatch.length >= MAX_FILE_UPLOAD_COUNT;
-
-    const nextBatchWouldOverflowBytes =
-      currentBatch.length > 0 &&
-      currentBatchBytes + file.size > MAX_FILE_UPLOAD_BATCH_BYTES;
-
-    if (nextBatchWouldOverflowCount || nextBatchWouldOverflowBytes) {
-      batches.push(currentBatch);
-
-      currentBatch = [];
-
-      currentBatchBytes = 0;
-    }
-
-    currentBatch.push(file);
-
-    currentBatchBytes += file.size;
-  }
-
-  if (currentBatch.length > 0) {
-    batches.push(currentBatch);
-  }
-
-  return batches;
 }
 
 async function downloadBlobFromUrl(url: string, filename: string) {
@@ -323,19 +160,13 @@ export function FileManagerWorkspace({
 
   const restoredFolderIdRef = useRef<string | null>(null);
 
-  const {
-    currentUploadingBatchRef,
-    pendingUploads,
-    queuedUploadsCount,
-    setPendingUploads,
-    setQueuedUploadsCount,
-    setUploadPaused,
-    uploadAbortControllerRef,
-    uploadPaused,
-    uploadPausedRef,
-    uploadProcessingRef,
-    uploadQueueRef,
-  } = useFileUploadFlow();
+  const loadFoldersRef = useRef<
+    (preferredFolderId?: string | null) => Promise<void>
+  >(async () => {});
+
+  const loadActiveFolderRef = useRef<(folderId: string) => Promise<void>>(
+    async () => {},
+  );
 
   const [folders, setFolders] = useState<FileFolderSummary[]>([]);
 
@@ -356,6 +187,29 @@ export function FileManagerWorkspace({
   const [error, setError] = useState<string | null>(null);
 
   const [info, setInfo] = useState<string | null>(null);
+
+  const {
+    cancelAllUploads,
+    cancelQueuedUploads,
+    enqueueUploadFiles,
+    pauseUploads,
+    pendingUploads,
+    queuedUploadsCount,
+    resumeUploads,
+    uploadPaused,
+  } = useFileUploadFlow({
+    accessToken,
+    devRole,
+    getActiveFolderId: () => activeFolderIdRef.current,
+    loadActiveFolder: (folderId) => loadActiveFolderRef.current(folderId),
+    loadFolders: (preferredFolderId) =>
+      loadFoldersRef.current(preferredFolderId),
+    onNavigateToFolder: (folderId) => {
+      navigateToFolder(folderId);
+    },
+    setError,
+    setInfo,
+  });
 
   const [createPanel, setCreatePanel] = useState<CreatePanelState>(null);
 
@@ -659,6 +513,9 @@ export function FileManagerWorkspace({
     [accessToken, devRole],
   );
 
+  loadFoldersRef.current = loadFolders;
+  loadActiveFolderRef.current = loadActiveFolder;
+
   useEffect(() => {
     void loadFolders();
   }, [loadFolders]);
@@ -700,230 +557,6 @@ export function FileManagerWorkspace({
       return changed ? Array.from(next) : current;
     });
   }, [activeFolder, rootFolders]);
-
-  const removePendingUploads = useCallback((pendingIds: string[]) => {
-    const pendingIdSet = new Set(pendingIds);
-
-    setPendingUploads((current) => {
-      const next: PendingUploadItem[] = [];
-
-      for (const item of current) {
-        if (pendingIdSet.has(item.id)) {
-          if (item.previewUrl) {
-            URL.revokeObjectURL(item.previewUrl);
-          }
-
-          continue;
-        }
-
-        next.push(item);
-      }
-
-      return next;
-    });
-  }, []);
-
-  const updatePendingUploadStatus = useCallback(
-    (pendingIds: string[], status: PendingUploadItem["status"]) => {
-      const pendingIdSet = new Set(pendingIds);
-
-      setPendingUploads((current) =>
-        current.map((item) =>
-          pendingIdSet.has(item.id) ? { ...item, status } : item,
-        ),
-      );
-    },
-    [],
-  );
-
-  const processUploadQueue = useCallback(async () => {
-    if (uploadProcessingRef.current) return;
-
-    uploadProcessingRef.current = true;
-
-    while (uploadQueueRef.current.length > 0) {
-      if (uploadPausedRef.current) {
-        break;
-      }
-
-      const batch = uploadQueueRef.current[0];
-
-      if (!batch) break;
-
-      setQueuedUploadsCount(uploadQueueRef.current.length);
-
-      updatePendingUploadStatus(batch.pendingIds, "uploading");
-      const controller = new AbortController();
-      uploadAbortControllerRef.current = controller;
-      currentUploadingBatchRef.current = batch;
-
-      setError(null);
-
-      try {
-        const metas = batch.files.map((file) => ({
-          fileName: file.name,
-          mimeType: file.type || "application/octet-stream",
-          sizeBytes: file.size,
-        }));
-        const prepared = await prepareFolderUploads(batch.folderId, metas, {
-          accessToken,
-          devRole,
-        });
-        const entries = prepared.entries;
-        for (let i = 0; i < batch.files.length; i++) {
-          const file = batch.files[i];
-          const plan = entries[i];
-          if (!plan) throw new Error("Plano de upload incompleto");
-          const res = await fetch(plan.signedUrl, {
-            method: "PUT",
-            headers: {
-              "content-type": plan.mimeType,
-              "x-upsert": "false",
-            },
-            body: file,
-            signal: controller.signal,
-          });
-          if (!res.ok) {
-            const txt = await res.text().catch(() => "");
-            throw new Error(txt || `Falha no upload de ${file.name}`);
-          }
-        }
-        await finalizeFolderUploads(
-          batch.folderId,
-          entries.map((e) => ({
-            fileId: e.fileId,
-            fileName: e.fileName,
-            mimeType: e.mimeType,
-            sizeBytes: e.sizeBytes,
-            storagePath: e.storagePath,
-          })),
-          { accessToken, devRole },
-        );
-
-        await loadFolders(batch.folderId);
-
-        if (activeFolderIdRef.current === batch.folderId) {
-          await loadActiveFolder(batch.folderId);
-        }
-
-        setInfo(`${batch.files.length} arquivo(s) enviado(s) com sucesso.`);
-      } catch (nextError) {
-        {
-          const err = (nextError ?? {}) as {
-            status?: number;
-            code?: string;
-            message?: unknown;
-          };
-          const aborted =
-            err &&
-            typeof err === "object" &&
-            err.status === 408 &&
-            err.code === "REQUEST_TIMEOUT";
-          if (aborted) {
-            updatePendingUploadStatus(batch.pendingIds, "canceled");
-            removePendingUploads(batch.pendingIds);
-            setInfo("Upload cancelado.");
-          } else {
-            const nextAttempts = (batch.attempts ?? 0) + 1;
-            const delay = Math.min(
-              BASE_UPLOAD_RETRY_DELAY_MS *
-                Math.pow(2, Math.max(0, nextAttempts - 1)),
-              MAX_UPLOAD_RETRY_DELAY_MS,
-            );
-            if (nextAttempts < MAX_UPLOAD_ATTEMPTS) {
-              updatePendingUploadStatus(batch.pendingIds, "queued");
-              if (uploadQueueRef.current.length <= 1) {
-                await new Promise((resolve) => setTimeout(resolve, delay));
-              }
-              uploadQueueRef.current.push({ ...batch, attempts: nextAttempts });
-              setError(
-                err?.message
-                  ? String(err.message)
-                  : "Falha ao enviar arquivos. Repetindo...",
-              );
-            } else {
-              updatePendingUploadStatus(batch.pendingIds, "failed");
-              setError(
-                err?.message
-                  ? String(err.message)
-                  : "Falha ao enviar arquivos apos multiplas tentativas.",
-              );
-            }
-          }
-        }
-      } finally {
-        uploadAbortControllerRef.current = null;
-        currentUploadingBatchRef.current = null;
-        uploadQueueRef.current.shift();
-
-        setQueuedUploadsCount(uploadQueueRef.current.length);
-
-        const wasRequeued = uploadQueueRef.current.find(
-          (b) => b.id === batch.id && b.attempts > batch.attempts,
-        );
-        if (!wasRequeued) {
-          removePendingUploads(batch.pendingIds);
-        }
-      }
-    }
-
-    uploadProcessingRef.current = false;
-  }, [
-    accessToken,
-    devRole,
-    loadActiveFolder,
-    loadFolders,
-    removePendingUploads,
-    updatePendingUploadStatus,
-  ]);
-
-  // Upload controls
-  const pauseUploads = useCallback(() => {
-    setUploadPaused(true);
-  }, []);
-
-  const resumeUploads = useCallback(() => {
-    setUploadPaused(false);
-    if (uploadQueueRef.current.length > 0 && !uploadProcessingRef.current) {
-      void processUploadQueue();
-    }
-  }, [processUploadQueue]);
-
-  const cancelQueuedUploads = useCallback(() => {
-    const queue = uploadQueueRef.current;
-    if (queue.length === 0) return;
-    const toCancel = queue.slice(uploadProcessingRef.current ? 1 : 0);
-    const pendingIds = toCancel.flatMap((b) => b.pendingIds);
-    uploadQueueRef.current = queue.slice(
-      0,
-      uploadProcessingRef.current ? 1 : 0,
-    );
-    setQueuedUploadsCount(uploadQueueRef.current.length);
-    updatePendingUploadStatus(pendingIds, "canceled");
-    removePendingUploads(pendingIds);
-    setInfo("Lotes em fila cancelados.");
-  }, [removePendingUploads, updatePendingUploadStatus, setInfo]);
-
-  const cancelAllUploads = useCallback(() => {
-    const controller = uploadAbortControllerRef.current;
-    const current = currentUploadingBatchRef.current;
-    const queued = uploadQueueRef.current;
-    const pendingIds = [
-      ...(current?.pendingIds ?? []),
-      ...queued.flatMap((b) => b.pendingIds),
-    ];
-    if (controller) {
-      try {
-        controller.abort();
-      } catch {}
-    }
-    uploadQueueRef.current = [];
-    setQueuedUploadsCount(0);
-    updatePendingUploadStatus(pendingIds, "canceled");
-    removePendingUploads(pendingIds);
-    setUploadPaused(false);
-    setInfo("Upload cancelado para todos os lotes.");
-  }, [removePendingUploads, updatePendingUploadStatus, setInfo]);
 
   function openCreatePanel(parentFolderId: string | null) {
     setCreatePanel({ parentFolderId });
@@ -1069,110 +702,21 @@ export function FileManagerWorkspace({
     }
   }
 
-  async function handleUpload(filesLike: FileList | File[], folderId: string) {
-    if (!canManage) return;
+  const handleUpload = useCallback(
+    async (filesLike: FileList | File[], folderId: string) => {
+      if (!canManage) return;
 
-    const files = Array.from(filesLike);
+      setFolderDropTargetId(null);
+      setActiveUploadDropzone(false);
 
-    if (files.length === 0) {
-      setError("Selecione ao menos um arquivo.");
+      await enqueueUploadFiles(filesLike, folderId);
 
-      return;
-    }
-
-    setError(null);
-
-    setInfo(null);
-
-    setFolderDropTargetId(null);
-
-    setActiveUploadDropzone(false);
-
-    navigateToFolder(folderId);
-
-    const batches = splitFilesIntoUploadBatches(files);
-
-    const pendingBatches = batches.map((batchFiles) => {
-      const createdAt = new Date().toISOString();
-
-      const batchId = createLocalId();
-
-      const pendingItems: PendingUploadItem[] = batchFiles.map((file) => ({
-        id: createLocalId(),
-
-        batchId,
-
-        folderId,
-
-        fileName: file.name,
-
-        file,
-
-        mimeType: file.type || "application/octet-stream",
-
-        sizeBytes: file.size,
-
-        previewUrl: isPreviewableFile(file.type, file.name)
-          ? URL.createObjectURL(file)
-          : null,
-
-        createdAt,
-
-        status: "queued",
-
-        attempts: 0,
-
-        errorMessage: null,
-      }));
-
-      return {
-        id: batchId,
-
-        folderId,
-
-        files: batchFiles,
-
-        pendingIds: pendingItems.map((item) => item.id),
-
-        pendingItems,
-
-        attempts: 0,
-      };
-    });
-
-    setPendingUploads((current) => [
-      ...pendingBatches.flatMap((batch) => batch.pendingItems),
-      ...current,
-    ]);
-
-    uploadQueueRef.current.push(
-      ...pendingBatches.map((batch) => ({
-        id: batch.id,
-
-        folderId: batch.folderId,
-
-        files: batch.files,
-
-        pendingIds: batch.pendingIds,
-
-        attempts: batch.attempts,
-      })),
-    );
-
-    setQueuedUploadsCount(uploadQueueRef.current.length);
-
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-
-    setInfo(
-      batches.length > 1
-        ? `${files.length} arquivo(s) adicionados em ${batches.length} lote(s) para upload.`
-        : `${files.length} arquivo(s) adicionados para upload.`,
-    );
-
-    void processUploadQueue();
-  }
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    },
+    [canManage, enqueueUploadFiles],
+  );
 
   async function handleDeleteFile(fileId: string) {
     if (!canManage || !activeFolder || submitting) return;
@@ -1806,7 +1350,11 @@ export function FileManagerWorkspace({
               />
 
               <div className="files-list-actions">
-                <button type="submit" className={styles.btn} disabled={submitting}>
+                <button
+                  type="submit"
+                  className={styles.btn}
+                  disabled={submitting}
+                >
                   Salvar
                 </button>
 
@@ -2277,7 +1825,11 @@ export function FileManagerWorkspace({
                 placeholder="Descricao"
               />
 
-              <button type="submit" className={styles.btn} disabled={submitting}>
+              <button
+                type="submit"
+                className={styles.btn}
+                disabled={submitting}
+              >
                 {submitting ? "Salvando..." : "Criar pasta"}
               </button>
             </form>
@@ -2336,7 +1888,11 @@ export function FileManagerWorkspace({
                 placeholder="Descricao"
               />
 
-              <button type="submit" className={styles.btn} disabled={submitting}>
+              <button
+                type="submit"
+                className={styles.btn}
+                disabled={submitting}
+              >
                 {submitting ? "Salvando..." : "Salvar alteracoes"}
               </button>
             </form>

--- a/components/files/file-order.ts
+++ b/components/files/file-order.ts
@@ -1,0 +1,23 @@
+import type { FileItem } from "@/components/files/types";
+
+export function reorderFiles(
+  files: FileItem[],
+  draggedId: string,
+  targetId: string,
+) {
+  const sourceIndex = files.findIndex((file) => file.id === draggedId);
+  const targetIndex = files.findIndex((file) => file.id === targetId);
+
+  if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) {
+    return files;
+  }
+
+  const next = [...files];
+  const [moved] = next.splice(sourceIndex, 1);
+  next.splice(targetIndex, 0, moved);
+
+  return next.map((file, index) => ({
+    ...file,
+    sortOrder: index,
+  }));
+}

--- a/components/files/folder-tree.ts
+++ b/components/files/folder-tree.ts
@@ -1,0 +1,48 @@
+import type { FileFolderSummary } from "@/components/files/types";
+
+export type FolderTreeNode = FileFolderSummary & {
+  children: FolderTreeNode[];
+};
+
+export function buildFolderTree(folders: FileFolderSummary[]) {
+  const nodeById = new Map<string, FolderTreeNode>();
+
+  for (const folder of folders) {
+    nodeById.set(folder.id, { ...folder, children: [] });
+  }
+
+  const roots: FolderTreeNode[] = [];
+
+  for (const folder of folders) {
+    const node = nodeById.get(folder.id);
+    if (!node) continue;
+
+    if (folder.parentFolderId && nodeById.has(folder.parentFolderId)) {
+      nodeById.get(folder.parentFolderId)?.children.push(node);
+      continue;
+    }
+
+    roots.push(node);
+  }
+
+  function sortNodes(nodes: FolderTreeNode[]) {
+    nodes.sort((left, right) => left.name.localeCompare(right.name, "pt-BR"));
+    for (const node of nodes) sortNodes(node.children);
+  }
+
+  sortNodes(roots);
+  return roots;
+}
+
+export function flattenFolderOptions(
+  nodes: FolderTreeNode[],
+  level = 0,
+): Array<{ id: string; label: string }> {
+  return nodes.flatMap((node) => [
+    {
+      id: node.id,
+      label: `${"  ".repeat(level)}${node.name}`,
+    },
+    ...flattenFolderOptions(node.children, level + 1),
+  ]);
+}

--- a/components/files/hooks/use-file-upload-flow.ts
+++ b/components/files/hooks/use-file-upload-flow.ts
@@ -1,38 +1,91 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-export type PendingUploadStatus =
-  | "queued"
-  | "uploading"
-  | "failed"
-  | "canceled"
-  | "completed";
+import {
+  finalizeFolderUploads,
+  prepareFolderUploads,
+} from "@/components/files/api";
+import type {
+  PendingUploadBatch,
+  PendingUploadItem,
+} from "@/components/files/upload-types";
+import type { Role } from "@/components/ui-grid/types";
+import {
+  MAX_FILE_UPLOAD_BATCH_BYTES,
+  MAX_FILE_UPLOAD_COUNT,
+  isPreviewableFile,
+} from "@/lib/files/shared";
 
-export type PendingUploadItem = {
-  id: string;
-  batchId: string;
-  folderId: string;
-  fileName: string;
-  file: File;
-  mimeType: string;
-  sizeBytes: number;
-  previewUrl: string | null;
-  createdAt: string;
-  status: PendingUploadStatus;
-  attempts: number;
-  errorMessage?: string | null;
+const BASE_UPLOAD_RETRY_DELAY_MS = 1_500;
+const MAX_UPLOAD_RETRY_DELAY_MS = 30_000;
+const MAX_UPLOAD_ATTEMPTS = 5;
+
+type UseFileUploadFlowParams = {
+  accessToken: string | null;
+  devRole?: Role | null;
+  loadFolders: (preferredFolderId?: string | null) => Promise<void>;
+  loadActiveFolder: (folderId: string) => Promise<void>;
+  getActiveFolderId: () => string | null;
+  onNavigateToFolder?: (folderId: string) => void;
+  setError: (message: string | null) => void;
+  setInfo: (message: string | null) => void;
 };
 
-export type PendingUploadBatch = {
-  id: string;
-  folderId: string;
-  files: File[];
-  pendingIds: string[];
-  attempts: number;
-  nextRetryAt?: number;
-  canceled?: boolean;
-};
+function createLocalId() {
+  if (
+    typeof crypto !== "undefined" &&
+    typeof crypto.randomUUID === "function"
+  ) {
+    return crypto.randomUUID();
+  }
 
-export function useFileUploadFlow() {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function splitFilesIntoUploadBatches(files: File[]) {
+  const batches: File[][] = [];
+  let currentBatch: File[] = [];
+  let currentBatchBytes = 0;
+
+  for (const file of files) {
+    const nextBatchWouldOverflowCount =
+      currentBatch.length >= MAX_FILE_UPLOAD_COUNT;
+    const nextBatchWouldOverflowBytes =
+      currentBatch.length > 0 &&
+      currentBatchBytes + file.size > MAX_FILE_UPLOAD_BATCH_BYTES;
+
+    if (nextBatchWouldOverflowCount || nextBatchWouldOverflowBytes) {
+      batches.push(currentBatch);
+      currentBatch = [];
+      currentBatchBytes = 0;
+    }
+
+    currentBatch.push(file);
+    currentBatchBytes += file.size;
+  }
+
+  if (currentBatch.length > 0) {
+    batches.push(currentBatch);
+  }
+
+  return batches;
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  return error && typeof error === "object" && "message" in error
+    ? String((error as { message?: unknown }).message ?? fallback)
+    : fallback;
+}
+
+export function useFileUploadFlow({
+  accessToken,
+  devRole,
+  loadFolders,
+  loadActiveFolder,
+  getActiveFolderId,
+  onNavigateToFolder,
+  setError,
+  setInfo,
+}: UseFileUploadFlowParams) {
   const uploadQueueRef = useRef<PendingUploadBatch[]>([]);
   const pendingUploadsRef = useRef<PendingUploadItem[]>([]);
   const currentUploadingBatchRef = useRef<PendingUploadBatch | null>(null);
@@ -55,25 +108,312 @@ export function useFileUploadFlow() {
   useEffect(() => {
     return () => {
       for (const item of pendingUploadsRef.current) {
-        if (item.previewUrl) {
-          URL.revokeObjectURL(item.previewUrl);
-        }
+        if (item.previewUrl) URL.revokeObjectURL(item.previewUrl);
       }
     };
   }, []);
 
+  const removePendingUploads = useCallback((pendingIds: string[]) => {
+    const pendingIdSet = new Set(pendingIds);
+
+    setPendingUploads((current) => {
+      const next: PendingUploadItem[] = [];
+      for (const item of current) {
+        if (pendingIdSet.has(item.id)) {
+          if (item.previewUrl) URL.revokeObjectURL(item.previewUrl);
+          continue;
+        }
+        next.push(item);
+      }
+      return next;
+    });
+  }, []);
+
+  const updatePendingUploadStatus = useCallback(
+    (pendingIds: string[], status: PendingUploadItem["status"]) => {
+      const pendingIdSet = new Set(pendingIds);
+      setPendingUploads((current) =>
+        current.map((item) =>
+          pendingIdSet.has(item.id) ? { ...item, status } : item,
+        ),
+      );
+    },
+    [],
+  );
+
+  const processUploadQueue = useCallback(async () => {
+    if (uploadProcessingRef.current) return;
+    uploadProcessingRef.current = true;
+
+    while (uploadQueueRef.current.length > 0) {
+      if (uploadPausedRef.current) break;
+
+      const batch = uploadQueueRef.current[0];
+      if (!batch) break;
+
+      setQueuedUploadsCount(uploadQueueRef.current.length);
+      updatePendingUploadStatus(batch.pendingIds, "uploading");
+
+      const controller = new AbortController();
+      uploadAbortControllerRef.current = controller;
+      currentUploadingBatchRef.current = batch;
+      setError(null);
+
+      try {
+        const metas = batch.files.map((file) => ({
+          fileName: file.name,
+          mimeType: file.type || "application/octet-stream",
+          sizeBytes: file.size,
+        }));
+
+        const prepared = await prepareFolderUploads(batch.folderId, metas, {
+          accessToken,
+          devRole,
+        });
+
+        for (let i = 0; i < batch.files.length; i++) {
+          const file = batch.files[i];
+          const plan = prepared.entries[i];
+          if (!plan) throw new Error("Plano de upload incompleto");
+
+          const res = await fetch(plan.signedUrl, {
+            method: "PUT",
+            headers: {
+              "content-type": plan.mimeType,
+              "x-upsert": "false",
+            },
+            body: file,
+            signal: controller.signal,
+          });
+
+          if (!res.ok) {
+            const txt = await res.text().catch(() => "");
+            throw new Error(txt || `Falha no upload de ${file.name}`);
+          }
+        }
+
+        await finalizeFolderUploads(
+          batch.folderId,
+          prepared.entries.map((entry) => ({
+            fileId: entry.fileId,
+            fileName: entry.fileName,
+            mimeType: entry.mimeType,
+            sizeBytes: entry.sizeBytes,
+            storagePath: entry.storagePath,
+          })),
+          { accessToken, devRole },
+        );
+
+        await loadFolders(batch.folderId);
+
+        if (getActiveFolderId() === batch.folderId) {
+          await loadActiveFolder(batch.folderId);
+        }
+
+        setInfo(`${batch.files.length} arquivo(s) enviado(s) com sucesso.`);
+      } catch (nextError) {
+        const err = (nextError ?? {}) as { status?: number; code?: string };
+        const canceledByTimeout =
+          err.status === 408 && err.code === "REQUEST_TIMEOUT";
+
+        if (canceledByTimeout) {
+          updatePendingUploadStatus(batch.pendingIds, "canceled");
+          removePendingUploads(batch.pendingIds);
+          setInfo("Upload cancelado.");
+        } else {
+          const nextAttempts = (batch.attempts ?? 0) + 1;
+          const delay = Math.min(
+            BASE_UPLOAD_RETRY_DELAY_MS *
+              Math.pow(2, Math.max(0, nextAttempts - 1)),
+            MAX_UPLOAD_RETRY_DELAY_MS,
+          );
+
+          if (nextAttempts < MAX_UPLOAD_ATTEMPTS) {
+            updatePendingUploadStatus(batch.pendingIds, "queued");
+
+            if (uploadQueueRef.current.length <= 1) {
+              await new Promise((resolve) => setTimeout(resolve, delay));
+            }
+
+            uploadQueueRef.current.push({ ...batch, attempts: nextAttempts });
+            setError(
+              getErrorMessage(
+                nextError,
+                "Falha ao enviar arquivos. Repetindo...",
+              ),
+            );
+          } else {
+            updatePendingUploadStatus(batch.pendingIds, "failed");
+            setError(
+              getErrorMessage(
+                nextError,
+                "Falha ao enviar arquivos apos multiplas tentativas.",
+              ),
+            );
+          }
+        }
+      } finally {
+        uploadAbortControllerRef.current = null;
+        currentUploadingBatchRef.current = null;
+        uploadQueueRef.current.shift();
+        setQueuedUploadsCount(uploadQueueRef.current.length);
+
+        const wasRequeued = uploadQueueRef.current.find(
+          (queuedBatch) =>
+            queuedBatch.id === batch.id &&
+            queuedBatch.attempts > batch.attempts,
+        );
+
+        if (!wasRequeued) {
+          removePendingUploads(batch.pendingIds);
+        }
+      }
+    }
+
+    uploadProcessingRef.current = false;
+  }, [
+    accessToken,
+    devRole,
+    getActiveFolderId,
+    loadActiveFolder,
+    loadFolders,
+    removePendingUploads,
+    setError,
+    setInfo,
+    updatePendingUploadStatus,
+  ]);
+
+  const enqueueUploadFiles = useCallback(
+    async (filesLike: FileList | File[], folderId: string) => {
+      const files = Array.from(filesLike);
+      if (files.length === 0) {
+        setError("Selecione ao menos um arquivo.");
+        return;
+      }
+
+      setError(null);
+      setInfo(null);
+      onNavigateToFolder?.(folderId);
+
+      const batches = splitFilesIntoUploadBatches(files);
+      const pendingBatches = batches.map((batchFiles) => {
+        const createdAt = new Date().toISOString();
+        const batchId = createLocalId();
+
+        const pendingItems: PendingUploadItem[] = batchFiles.map((file) => ({
+          id: createLocalId(),
+          batchId,
+          folderId,
+          fileName: file.name,
+          file,
+          mimeType: file.type || "application/octet-stream",
+          sizeBytes: file.size,
+          previewUrl: isPreviewableFile(file.type, file.name)
+            ? URL.createObjectURL(file)
+            : null,
+          createdAt,
+          status: "queued",
+          attempts: 0,
+          errorMessage: null,
+        }));
+
+        return {
+          id: batchId,
+          folderId,
+          files: batchFiles,
+          pendingIds: pendingItems.map((item) => item.id),
+          pendingItems,
+          attempts: 0,
+        };
+      });
+
+      setPendingUploads((current) => [
+        ...pendingBatches.flatMap((batch) => batch.pendingItems),
+        ...current,
+      ]);
+
+      uploadQueueRef.current.push(
+        ...pendingBatches.map((batch) => ({
+          id: batch.id,
+          folderId: batch.folderId,
+          files: batch.files,
+          pendingIds: batch.pendingIds,
+          attempts: batch.attempts,
+        })),
+      );
+
+      setQueuedUploadsCount(uploadQueueRef.current.length);
+      setInfo(
+        batches.length > 1
+          ? `${files.length} arquivo(s) adicionados em ${batches.length} lote(s) para upload.`
+          : `${files.length} arquivo(s) adicionados para upload.`,
+      );
+
+      void processUploadQueue();
+    },
+    [onNavigateToFolder, processUploadQueue, setError, setInfo],
+  );
+
+  const pauseUploads = useCallback(() => setUploadPaused(true), []);
+
+  const resumeUploads = useCallback(() => {
+    setUploadPaused(false);
+    if (uploadQueueRef.current.length > 0 && !uploadProcessingRef.current) {
+      void processUploadQueue();
+    }
+  }, [processUploadQueue]);
+
+  const cancelQueuedUploads = useCallback(() => {
+    const queue = uploadQueueRef.current;
+    if (queue.length === 0) return;
+
+    const toCancel = queue.slice(uploadProcessingRef.current ? 1 : 0);
+    const pendingIds = toCancel.flatMap((batch) => batch.pendingIds);
+
+    uploadQueueRef.current = queue.slice(
+      0,
+      uploadProcessingRef.current ? 1 : 0,
+    );
+    setQueuedUploadsCount(uploadQueueRef.current.length);
+    updatePendingUploadStatus(pendingIds, "canceled");
+    removePendingUploads(pendingIds);
+    setInfo("Lotes em fila cancelados.");
+  }, [removePendingUploads, setInfo, updatePendingUploadStatus]);
+
+  const cancelAllUploads = useCallback(() => {
+    const controller = uploadAbortControllerRef.current;
+    const currentBatch = currentUploadingBatchRef.current;
+    const queued = uploadQueueRef.current;
+
+    const pendingIds = [
+      ...(currentBatch?.pendingIds ?? []),
+      ...queued.flatMap((batch) => batch.pendingIds),
+    ];
+
+    if (controller) {
+      try {
+        controller.abort();
+      } catch {
+        // noop
+      }
+    }
+
+    uploadQueueRef.current = [];
+    setQueuedUploadsCount(0);
+    updatePendingUploadStatus(pendingIds, "canceled");
+    removePendingUploads(pendingIds);
+    setUploadPaused(false);
+    setInfo("Upload cancelado para todos os lotes.");
+  }, [removePendingUploads, setInfo, updatePendingUploadStatus]);
+
   return {
-    currentUploadingBatchRef,
+    cancelAllUploads,
+    cancelQueuedUploads,
+    enqueueUploadFiles,
+    pauseUploads,
     pendingUploads,
-    pendingUploadsRef,
     queuedUploadsCount,
-    setPendingUploads,
-    setQueuedUploadsCount,
-    setUploadPaused,
-    uploadAbortControllerRef,
+    resumeUploads,
     uploadPaused,
-    uploadPausedRef,
-    uploadProcessingRef,
-    uploadQueueRef,
   };
 }

--- a/components/files/upload-types.ts
+++ b/components/files/upload-types.ts
@@ -1,0 +1,31 @@
+export type PendingUploadStatus =
+  | "queued"
+  | "uploading"
+  | "failed"
+  | "canceled"
+  | "completed";
+
+export type PendingUploadItem = {
+  id: string;
+  batchId: string;
+  folderId: string;
+  fileName: string;
+  file: File;
+  mimeType: string;
+  sizeBytes: number;
+  previewUrl: string | null;
+  createdAt: string;
+  status: PendingUploadStatus;
+  attempts: number;
+  errorMessage?: string | null;
+};
+
+export type PendingUploadBatch = {
+  id: string;
+  folderId: string;
+  files: File[];
+  pendingIds: string[];
+  attempts: number;
+  nextRetryAt?: number;
+  canceled?: boolean;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "eslint": "^9.24.0",
         "eslint-config-next": "^15.3.3",
         "pg": "^8.11.5",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -55,6 +56,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -719,6 +1162,13 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -930,7 +1380,6 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -940,6 +1389,356 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -1055,6 +1854,24 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1097,7 +1914,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1166,7 +1982,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -1673,13 +2488,127 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1907,6 +2836,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -1991,6 +2930,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2071,6 +3020,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2086,6 +3052,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/client-only": {
@@ -2220,6 +3196,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2427,6 +3413,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2487,6 +3480,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2506,7 +3541,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2680,7 +3714,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2923,6 +3956,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2931,6 +3974,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4005,6 +5058,23 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4422,13 +5492,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pg": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -4710,7 +5796,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4720,7 +5805,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4829,6 +5913,51 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -5122,6 +6251,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5145,6 +6281,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5298,6 +6448,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -5347,6 +6517,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5388,12 +6572,41 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5538,7 +6751,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5615,6 +6827,265 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/which": {
@@ -5720,6 +7191,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "supabase:types": "npx supabase gen types --project-id $SUPABASE_PROJECT_REF --schema public --lang typescript > lib/supabase/database.types.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:unit": "vitest run components/files/__tests__"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",
@@ -26,6 +27,7 @@
     "@types/react-dom": "^19.0.4",
     "eslint": "^9.24.0",
     "eslint-config-next": "^15.3.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^3.2.4"
   }
 }


### PR DESCRIPTION
### Motivation
- Centralize and isolate upload queue and lifecycle logic (status transitions, retry/backoff, pause/resume, cancel) into a dedicated hook to remove transition logic from the page component.
- Extract pure folder-tree and file-order utilities to a local domain module so they can be unit-tested and reused without UI code.
- Standardize upload state types to avoid contract drift across modules and make the workspace component a pure compositor of sections.
- Prepare for incremental reduction of `file-manager-workspace.tsx` size by moving responsibilities into focused modules.

### Description
- Moved upload queue lifecycle (batching, enqueue, processing, retry/backoff, pause/resume, cancel) into `components/files/hooks/use-file-upload-flow.ts` and changed the workspace to consume that hook via a typed API.
- Introduced shared upload types in `components/files/upload-types.ts` for `PendingUploadStatus`, `PendingUploadItem`, and `PendingUploadBatch`.
- Extracted pure domain helpers `buildFolderTree`/`flattenFolderOptions` into `components/files/folder-tree.ts` and `reorderFiles` into `components/files/file-order.ts` and updated imports in the workspace.
- Replaced the long inline upload handler with a callback that calls the hook's `enqueueUploadFiles`, and wired hook controls (`pauseUploads`, `resumeUploads`, `cancelQueuedUploads`, `cancelAllUploads`) into the UI.
- Added unit tests for the folder tree and file-order utilities under `components/files/__tests__` and added `vitest` + `test:unit` script to `package.json`.
- Kept `file-manager-workspace.tsx` as the composition layer (toolbar/command bar/preview/manage sections) while delegating upload state and pure algorithms to the new modules.

### Testing
- Ran `npm run test:unit` (`vitest run components/files/__tests__`) and the two new test files passed (4 tests total) ✅.
- Ran `npm run lint` (`next lint`) which completed with only warnings (no blocking errors) ✅.
- Ran `npm run build` (`next build`) which failed due to a pre-existing CSS syntax error in `app/globals.css` unrelated to this refactor (build failed) ⚠️.
- Checked file length with `wc -l components/files/file-manager-workspace.tsx`: current count `2380` lines and the Phase-1 target `<= 1835` is not yet met.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e738954883289653a8fe6ad0011d)