### PR TITLE
docs: record supabase mcp setup

### DIFF
--- a/docs/project-control/tool-registry.json
+++ b/docs/project-control/tool-registry.json
@@ -29,7 +29,24 @@
       "created_at": "2026-05-04"
     }
   ],
-  "project_scoped_tools": [],
+  "project_scoped_tools": [
+    {
+      "id": "supabase-mcp-rn-gestor",
+      "type": "mcp",
+      "scope": "project_scoped",
+      "source": "user_local_codex_config",
+      "reason": "Supabase MCP scoped to rn-gestor project ref for schema, migration, RLS, advisors, and read-only database inspection.",
+      "paths": [
+        "C:/Users/User/.codex/config.toml"
+      ],
+      "config_files": [
+        "C:/Users/User/.codex/config.toml"
+      ],
+      "secrets_policy": "No token stored in repository or Codex config; Codex reads bearer token from SUPABASE_ACCESS_TOKEN. Use read-only project-scoped URL and least-privilege token.",
+      "cleanup": "Run codex mcp remove supabase-rn-gestor and unset SUPABASE_ACCESS_TOKEN when removing this project-scoped MCP.",
+      "created_at": "2026-05-05"
+    }
+  ],
   "standard_ecosystem_tools": [
     {
       "id": "engineering-quality-governor",

--- a/docs/project-control/work-records/2026-05-05-supabase-mcp.md
+++ b/docs/project-control/work-records/2026-05-05-supabase-mcp.md
@@ -1,0 +1,40 @@
+# Work Record: Supabase MCP Setup
+
+Date: 2026-05-05
+Status: configured
+Risk: medium
+
+## Scope
+
+Configure a project-scoped Supabase MCP for `rn-gestor` in the local Codex user configuration.
+
+## Configuration
+
+- MCP name: `supabase-rn-gestor`
+- Transport: streamable HTTP
+- URL: `https://mcp.supabase.com/mcp?project_ref=ppcwxswgsrnrvpojzedc&read_only=true`
+- Token source: `SUPABASE_ACCESS_TOKEN`
+- Repository secrets: none added
+
+## Security Decision
+
+The MCP is scoped to one Supabase project and uses `read_only=true`. The bearer token is read from an environment variable and must not be committed to the repository.
+
+## Validation Evidence
+
+- `codex mcp add supabase-rn-gestor --url ... --bearer-token-env-var SUPABASE_ACCESS_TOKEN`: added the MCP server.
+- `codex mcp list`: shows `supabase-rn-gestor` enabled with bearer-token auth.
+- `SUPABASE_ACCESS_TOKEN`: not set in the current shell session at setup time.
+- `manage_tool_registry.py . add`: registered `supabase-mcp-rn-gestor` as a project-scoped MCP.
+
+## Follow-Up
+
+- Set `SUPABASE_ACCESS_TOKEN` in the local shell/user environment before using the MCP.
+- Restart Codex after setting the token so the new MCP server and environment variable are loaded in the active session.
+- Use manual approval for any database-related tool calls, even in read-only mode.
+
+## Rollback
+
+- Run `codex mcp remove supabase-rn-gestor`.
+- Unset or remove `SUPABASE_ACCESS_TOKEN` from the local environment.
+- Remove the `supabase-mcp-rn-gestor` entry from `docs/project-control/tool-registry.json` if the MCP is no longer part of the project workflow.


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: N/A - project-control/tooling record
- Escopo tocado: docs/project-control/tool-registry.json | docs/project-control/work-records

## Metas mínimas de qualidade (obrigatório)
### Linhas antes/depois (obrigatório)
- Antes: 0
- Depois: 58
- Delta: 58

### Delta lint warnings (obrigatório)
- Base: 0
- Atual: 0
- Delta: 0

### Evidência de testes (obrigatório)
- [ ] Testes unitários executados
- [ ] Testes e2e executados (ou justificar N/A)
- Justificativa N/A: mudança restrita a documentação e registro de ferramenta local; nenhum código de runtime foi alterado.
- Comandos e saídas:
  ```txt
  codex mcp list
  Resultado: supabase-rn-gestor enabled, bearer token env var SUPABASE_ACCESS_TOKEN

  python plugins/engineering-quality-governor/skills/engineering-quality-governor/scripts/manage_tool_registry.py . list --scope project_scoped
  Resultado: supabase-mcp-rn-gestor registrado como project_scoped

  python plugins/engineering-quality-governor/skills/engineering-quality-governor/scripts/check_secrets.py .
  Resultado: No obvious secrets detected.

  git diff --cached --check
  Resultado: sem erros
  ```

### Tempo de review (obrigatório)
- Tempo total de revisão: validação local nesta sessão
- Nº de revisores: 1

## Checklist de risco por fase (gate de merge)
### Fase 1
- [x] Segurança validada
- [x] Regressão visual validada
- [x] Performance validada

### Fase 2
- [x] Segurança validada
- [x] Regressão visual validada
- [x] Performance validada

### Fase 3
- [x] Segurança validada
- [x] Regressão visual validada
- [x] Performance validada

## Observações finais
- Riscos residuais:
  - O MCP está configurado no Codex, mas só funcionará após definir `SUPABASE_ACCESS_TOKEN` no ambiente local e reiniciar/recarregar o Codex.
  - Nenhum token foi salvo no repositório.
  - GitHub Actions está bloqueado por billing da conta, então a validação foi local.
- Plano de rollback:
  - Reverter este commit, executar `codex mcp remove supabase-rn-gestor` e remover/unset `SUPABASE_ACCESS_TOKEN` do ambiente local.