### PR TITLE
docs(agents): rewrite AGENTS.md using Karpathy method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,47 +1,165 @@
-# Repository Guidelines
+# AGENTS.md — rn-gestor-web
 
-## Project Structure & Module Organization
+> Spec terso para agentes. Releia a cada turn. Se algo aqui está desatualizado, **corrija aqui antes de codar**.
 
-- `app/`: pages, layouts, and API route handlers. API endpoints live under `app/api/v1/**/route.ts`.
-- `components/`: React UI modules, grouped by feature (`ui-grid`, `files`, `auth`, `admin`) plus shared atoms in `components/atoms/`.
-- `lib/`: domain, API, Supabase, formatting, guard, mapper, and shared service code. Prefer placing business logic here instead of inside route handlers.
-- `styles/` and `app/globals.css`: global styling and design tokens.
-- `supabase/`: migrations, config, README, and Edge Functions.
-- `tests/e2e/`: Playwright specs and fixtures. Unit tests live near source in `__tests__`.
-- `docs/` and `scripts/`: refactor plans, metrics baselines, and automation.
+## O que este repo é
 
-## Build, Test, and Development Commands
+App **Next.js 15 (App Router) + React 19 + Supabase**. O nome `rn-gestor` é histórico — **não é React Native**. Backend-mediated: o browser fala com Next API Routes, e só o servidor toca Supabase com `service_role`.
 
-- `npm ci`: install exact dependencies from `package-lock.json`.
-- `npm run dev`: start the local Next.js server.
-- `npm run build`: create a production build.
-- `npm run start`: serve the production build.
-- `npm run lint`: run the configured Next/TypeScript ESLint rules.
-- `npm run test:unit`: run Vitest unit tests.
-- `npm run test:e2e`: run Playwright against `http://127.0.0.1:3100`.
-- `npm run supabase:types`: regenerate `lib/supabase/database.types.ts` from Supabase.
-- `npm run metrics:gate`: run the refactor quality gate used by CI.
+## Invariantes não-óbvios (leia antes de tocar em código)
 
-## Coding Style & Naming Conventions
+1. **Nenhum componente de cliente acessa Supabase direto em tabelas do `public`.** RLS está habilitado mas sem políticas em muitas tabelas, por design. Toda leitura/escrita passa por `app/api/v1/**`. Quebrar isso = vazamento.
+2. **`SUPABASE_SECRET_KEY` / `SUPABASE_SERVICE_ROLE_KEY` só existem no servidor.** Nunca importe de `lib/supabase/admin.ts` em arquivos client.
+3. **Rotas de API são thin.** Validação, persistência e regras vão em `lib/api/**` ou `lib/domain/**`. Veja [lib/api/execute.ts](lib/api/execute.ts) como contrato canônico.
+4. **Grid e Files seguem config-driven com allow-list.** Nunca aceite `table`/`column`/`row_id` arbitrários do cliente — sempre cruze com `GRID_TABLE_POLICIES` em [lib/domain/grid-policy.ts](lib/domain/grid-policy.ts).
+5. **RBAC é hierárquico:** `VENDEDOR < SECRETARIO < GERENTE < ADMINISTRADOR`. Use `requireRole(actor, "GERENTE")` de [lib/api/auth.ts](lib/api/auth.ts), não comparações ad-hoc.
+6. **Migrações Supabase são fonte de verdade do schema.** Se mudou tabela/coluna/policy, gere `.sql` em `supabase/migrations/` antes de mexer em TS.
+7. **Mojibake é uma realidade do banco.** Use [lib/ux/mojibake.ts](lib/ux/mojibake.ts) ao exibir strings legadas — não normalize na origem sem migração explícita.
 
-Use strict TypeScript and 2-space indentation. Follow existing naming: kebab-case files for components and modules (`file-manager-workspace.tsx`), `useCamelCase` for hooks, `route.ts` for API handlers, and `page.tsx` for routes. Prefer `@/` imports for repository-local modules. Keep route handlers thin; move validation, persistence, and business rules into `lib/api` or `lib/domain`.
+## Padrões canônicos — copie destes arquivos
 
-## Testing Guidelines
+| Cenário | Olhe primeiro | Por quê |
+|---|---|---|
+| Nova rota de API autenticada | [app/api/v1/me/route.ts](app/api/v1/me/route.ts) | Usa `executeAuthenticatedApi` corretamente |
+| Rota com role mínimo | [app/api/v1/insights/anuncios/missing-rows/route.ts](app/api/v1/insights/anuncios/missing-rows/route.ts) | Padrão `requireRole` + `apiOk` |
+| Serviço de domínio | [lib/domain/file-automations/service.ts](lib/domain/file-automations/service.ts) | `ApiHttpError` + types do `Database` |
+| Cliente HTTP no browser | [components/files/api.ts](components/files/api.ts) | (a consolidar — ver Gotcha #2) |
+| Client Supabase no servidor | [lib/api/supabase-admin.ts](lib/api/supabase-admin.ts) | `getSupabaseAdmin()` com guarda de env |
+| Hook de grid | [components/ui-grid/hooks/useGridDataSource.ts](components/ui-grid/hooks/useGridDataSource.ts) | Separação loading/seleção/mutação |
+| Teste unitário de domínio | [lib/domain/__tests__/anuncios-insights.test.ts](lib/domain/__tests__/anuncios-insights.test.ts) | Vitest + fixtures inline |
+| Spec E2E | [tests/e2e/files.spec.ts](tests/e2e/files.spec.ts) | Playwright contra `127.0.0.1:3100` |
 
-Use Vitest for unit tests and Playwright for E2E coverage. Name unit tests `*.test.ts` or `*.test.tsx` inside `__tests__` next to the module. Name E2E specs `*.spec.ts` under `tests/e2e/`. For UI/API behavior changes, run the narrowest relevant test plus `npm run build`; for grid or file workflows, include Playwright when practical.
+## DO / DON'T
 
-## Commit & Pull Request Guidelines
+**Validação de input em rotas (P0 da auditoria).**
+```ts
+// DON'T — cast direto, sem validação runtime
+const body = (await req.json()) as { table: string; column: string };
 
-Git history uses short imperative commits, sometimes with a scope, for example `refactor(ui-grid): extract sheet composition hooks`. PRs should complete `.github/pull_request_template.md`: phase context, touched scope, line/lint deltas, test evidence, review time, risk checklist, residual risks, and rollback plan.
+// DO — validar com guard ou schema antes de usar
+const body = await req.json();
+if (!isValidGridMutation(body)) throw new ApiHttpError(400, "BAD_BODY", "Payload inválido.");
+```
 
-## Security & Configuration Tips
+**Resposta de erro (P0 da auditoria).**
+```ts
+// DON'T — vazar objeto Supabase cru ao cliente
+if (error) throw new ApiHttpError(500, "X_FAILED", "Falhou.", error);
 
-Create `.env.local` with the variables documented in `README.md`; no environment template is currently versioned. Keep Supabase secrets out of commits. Public browser variables must use `NEXT_PUBLIC_`. Server-only keys such as `SUPABASE_SECRET_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, and `EDGE_INTERNAL_KEY` belong only in local or deployment configuration.
+// DO — logar detalhes server-side, retornar mensagem segura
+if (error) {
+  console.error("[X_FAILED]", { requestId, error });
+  throw new ApiHttpError(500, "X_FAILED", "Falhou.");
+}
+```
 
-## Engineering Quality Governor
+**Cliente HTTP duplicado (P1 da auditoria).**
+```ts
+// DON'T — criar mais um fetchWithTimeout local
+async function myFetch(url: string) { /* ... */ }
 
-For every interaction in this repository, keep the engineering ecosystem active. Operate as a senior strategic software engineering consultant, product-minded system designer, pragmatic software architect, and hands-on developer with 10+ years of professional experience. This stance is not optional and should be active before analysis, planning, implementation, review, validation, commit, push, MCP/database work, or troubleshooting.
+// DO — reusar o módulo compartilhado (consolidar quando criado)
+import { apiFetch } from "@/components/shared/api-client";
+```
 
-For every software-project or code-related task, apply the local `engineering-quality-governor` workflow. Start with a quick project-health and project-control check, surface missing fundamentals such as `.gitignore`, README, `AGENTS.md`, env documentation, PRDs/specs, progress records, tests, CI, or quality gates, and then proceed with the smallest useful plan. Do not wait for the user to ask for engineering rigor: proactively check current worktree scope, relevant project-control records, tool registry impact, tests, CI/quality gates, security/configuration implications, and migration risk whenever they are relevant to the task. Project-scoped MCPs, skills, connectors, scripts, and generated configs must be recorded in `docs/project-control/tool-registry.json` so they can be removed during migration without deleting the reusable ecosystem.
+**Acesso ao banco no cliente.**
+```ts
+// DON'T
+const supa = createSupabaseBrowserClient();
+const { data } = await supa.from("carros").select("*");
 
-Before adding new logic, apply the bundled `code-reuse-architecture-prospector` workflow: search for existing functions, hooks, services, mappers, validators, components, and adapters; reuse or extend matching code when semantics fit; and only create a minimal shared composition layer when repeated policy or mechanism is real and inside scope.
+// DO — sempre via API Route
+const res = await fetch("/api/v1/carros");
+```
+
+**Mutação em grid.**
+```ts
+// DON'T — UPDATE direto sem allow-list
+.from(table).update({ [column]: value }).eq("id", id);
+
+// DO — passar pelo dispatcher que valida policy
+import { dispatchGridMutation } from "@/lib/api/grid/mutation-dispatcher";
+```
+
+## Gotchas
+
+1. **Monólitos quebram reviews.** `HolisticSheet` (~6.8k linhas), `FileManagerWorkspace` (~2.7k), `PlaygroundWorkspace` (~3.7k), `globals.css` (~9.3k). Antes de adicionar features novas aqui, **extraia primeiro** — ver `docs/refactor-roadmap-clean-architecture.md`.
+2. **`fetchWithTimeout`/`parseApi` está duplicado** em `components/ui-grid/api.ts`, `components/files/api.ts`, `components/admin/api.ts`. Se for tocar em um, considere consolidar.
+3. **`/api/v1/price-contexts`** aceita `table/row_id/column` livres e usa `client: any`. Tratar como área sensível — adicione allow-list antes de qualquer mudança.
+4. **`auditoria/dashboard`** filtra busca em memória e busca autores/tabelas sem paginação. Não escala — não adicione carga.
+5. **CI roda só `metrics:gate`.** Lint/build/testes ficam locais. Se mudar config de build, rode os três manualmente.
+6. **Worktrees em `.claude/worktrees/**`** são scratch space — nunca commit a partir de lá sem alinhar com o usuário.
+7. **`tmp-dev-server-*.log`** na raiz é lixo de execuções antigas. Não os trate como artefatos do projeto.
+8. **`citext` está em `public`** e Supabase Auth tem leaked-password protection desabilitado. Não dependa desses estados — eles vão mudar.
+
+## O que **não** fazer sem alinhamento
+
+- Adicionar dependência (especialmente runtime). Justifique no PR.
+- Mexer em `supabase/migrations/` antigas. Sempre crie nova migração com timestamp à frente.
+- Reescrever monólitos em um único PR. Quebre por caso de uso (data loading → seleção → edição → impressão).
+- Habilitar policies RLS sem desenhar o contrato de acesso direto cliente→banco. Hoje é deliberadamente backend-mediated.
+- Remover `__has_pending_action`, `__missing_data` e outros campos `__*` em rows do grid — são contrato com a UI.
+
+## Estrutura (resumo)
+
+- `app/`: páginas, layouts, **API em `app/api/v1/**/route.ts`**
+- `components/`: UI por feature (`ui-grid`, `files`, `auth`, `admin`, `playground`)
+- `lib/api/`: helpers HTTP, auth, dispatcher de mutação
+- `lib/domain/`: regras de negócio puras (testáveis sem Supabase)
+- `lib/supabase/`: clientes (server, browser, admin) + types gerados
+- `supabase/migrations/`: SQL versionado, fonte de verdade do schema
+- `tests/e2e/`: Playwright; unitários ficam em `__tests__` ao lado do módulo
+- `docs/project-control/`: work records, tool registry, estratégia RLS
+
+## Comandos
+
+| | |
+|---|---|
+| `npm ci` | install lockfile |
+| `npm run dev` | Next dev (porta 3000) |
+| `npm run build` | build produção |
+| `npm run lint` | ESLint Next/TS |
+| `npm run test:unit` | Vitest |
+| `npm run test:e2e` | Playwright (`127.0.0.1:3100`) |
+| `npm run supabase:types` | regenera `lib/supabase/database.types.ts` |
+| `npm run metrics:gate` | quality gate de refactor (CI) |
+
+## Estilo
+
+- TS strict, indent 2 espaços
+- kebab-case para arquivos (`file-manager-workspace.tsx`)
+- `useCamelCase` para hooks, `route.ts` para handlers, `page.tsx` para páginas
+- Imports `@/` para módulos do repo
+- **Sem comentários óbvios.** Só comente o "porquê" não-óbvio.
+- **Sem `any`** — se precisar, justifique no PR
+
+## Testes
+
+- Mudança em UI/API: rode o teste mais estreito relevante + `npm run build`
+- Mudança em grid/files: inclua Playwright quando prático
+- Nomes: `*.test.ts(x)` em `__tests__`, `*.spec.ts` em `tests/e2e/`
+- Domain logic deve ter teste unitário sem Supabase mock — extraia funções puras
+
+## Commits & PRs
+
+- Imperativo curto, com escopo: `refactor(ui-grid): extract sheet composition hooks`
+- PR completa `.github/pull_request_template.md`: phase context, scope, deltas de linha/lint, evidência de teste, risk checklist, rollback
+- Não amende commits empurrados; crie commit novo
+
+## Segurança & config
+
+- `.env.local` segue `README.md` (sem template versionado)
+- Vars públicas: prefixo `NEXT_PUBLIC_`
+- Server-only: `SUPABASE_SECRET_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `EDGE_INTERNAL_KEY` — **nunca** importadas em código que vai pro bundle do browser
+- Toda nova rota de API: pense "o que acontece se um VENDEDOR chamar isso?" antes de escrever
+
+## Engineering ecosystem (ativo por padrão)
+
+Atue como engenheiro sênior estratégico + arquiteto pragmático em todas as interações deste repo. Antes de plan/implementação/review/commit:
+
+1. **Project-health quick check.** Faltou `.gitignore`, README, env doc, PRD, work record, teste, CI, gate? Sinalize.
+2. **Code-reuse first.** Procure função/hook/serviço/mapper/validator/componente existente antes de criar novo. Reuse ou estenda quando a semântica bate. Crie nova abstração só quando há repetição real e dentro do escopo.
+3. **Tool registry.** MCPs, skills, connectors, scripts e configs gerados pelo projeto vão em `docs/project-control/tool-registry.json` para serem removíveis em migração sem destruir o ecossistema.
+4. **Work record.** Mudanças de arquitetura, segurança, ou que cruzam features ganham um arquivo em `docs/project-control/work-records/AAAA-MM-DD-titulo.md`.
+
+Workflow detalhado: [plugins/engineering-quality-governor/skills/engineering-quality-governor/SKILL.md](plugins/engineering-quality-governor/skills/engineering-quality-governor/SKILL.md). Para reuso: [plugins/engineering-quality-governor/skills/code-reuse-architecture-prospector/SKILL.md](plugins/engineering-quality-governor/skills/code-reuse-architecture-prospector/SKILL.md).

--- a/docs/project-control/work-records/2026-05-08-refactor-orchestration-wave1.md
+++ b/docs/project-control/work-records/2026-05-08-refactor-orchestration-wave1.md
@@ -1,0 +1,97 @@
+# 2026-05-08 — Refactor orchestration (Wave 1)
+
+## Context
+
+Codex gpt-5.5 xhigh audit (sessão `019e07da-427d-7b00-9cb6-856f294e8b19`) identificou prioridades P0/P1 no repo. Após reescrita do `AGENTS.md` no estilo Karpathy, Wave 1 do refactor foi disparada em paralelo com distribuição entre Codex e sub-agentes Claude.
+
+## Distribution
+
+| Tarefa | Prioridade | Agente | Worktree | Razão da escolha |
+|---|---|---|---|---|
+| Quebrar `HolisticSheet` (~6.8k linhas) | P1 (mais difícil) | Codex gpt-5.5 xhigh | `.claude/worktrees/refactor-holistic-sheet` (`refactor/holistic-sheet-monolith`) | Trabalho estrutural pesado, exige raciocínio profundo sobre acoplamento cruzado |
+| Sanitizar `details` de erro em prod | P0 (segurança) | Claude general-purpose | isolated (auto) | Repo-wide pattern matching, edição em vários callsites |
+| Consolidar client API (`fetchWithTimeout`/`parseApi` 3× duplicado) | P1 | Claude general-purpose | isolated (auto) | Cross-cutting, requer mover código sem quebrar consumers |
+| Endurecer `price-contexts` (`any`, allow-list, role) | P1 (segurança) | Claude general-purpose | isolated (auto) | Escopo focado em uma área, alta sensibilidade |
+
+## Conflict surface
+
+- **Codex (HolisticSheet) ↔ Agent 2 (Client API)** podem ambos tocar `components/ui-grid/api.ts`. Resolução em merge — Codex foi instruído a evitar reorganização desse arquivo.
+- Outros: tarefas tocam áreas disjuntas (lib/api/response.ts vs app/api/v1/price-contexts/** vs components/ui-grid/holistic-sheet.tsx).
+
+## Out of scope (Wave 2, próxima orquestração)
+
+- Quebra de `FileManagerWorkspace` (~2.7k) e `PlaygroundWorkspace` (~3.7k) — Codex xhigh em sequência
+- Validação runtime padronizada (Zod ou guards) nas rotas P0
+- CI expandido (`lint` + `test:unit` + `build` em PR)
+- Paginação server-side em `auditoria/dashboard`
+- Testes que garantam que nenhuma tela usa Supabase direto em tabelas sem policy
+
+## Validation strategy
+
+Cada agente roda testes escopados na sua worktree. Antes de qualquer merge: `npm ci && npm run lint && npm run test:unit && npm run build` no resultado consolidado.
+
+## Status (linha do tempo)
+
+| Hora | Evento |
+|---|---|
+| 2026-05-08 ~14:05 | AGENTS.md reescrito (Karpathy method) no worktree `sharp-joliot-221f0d` |
+| 2026-05-08 ~14:10 | Worktree `refactor-holistic-sheet` criado a partir de `main` |
+| 2026-05-08 ~14:10 | Wave 1 disparada em paralelo |
+| 2026-05-08 ~14:17 | Agent P0 (errors) finalizou |
+| 2026-05-08 ~14:18 | Agent P1 (client API) finalizou |
+| 2026-05-08 ~14:19 | Agent P1 (price-contexts) finalizou |
+| 2026-05-08 — | Codex (HolisticSheet) em andamento |
+
+## Resultados Wave 1
+
+### ✅ P0 — Sanitização de erros
+- **Branch:** `worktree-agent-a71e81d29fd09a2f6`
+- **Worktree:** `.claude/worktrees/agent-a71e81d29fd09a2f6`
+- **Commits:** `eb4b184` (testes), `0824d86` (filtro)
+- **Mudanças:** `lib/api/response.ts` filtra `details` em prod; `lib/api/execute.ts` loga `console.error("[CODE]", { requestId, error })` antes do throw
+- **Testes:** 69/69 ✅ (4 novos)
+- **Risco residual:** ~150 callsites passam erro Supabase cru — proteção agora está na serialização. Refactor explícito por callsite fica para PR futura.
+
+### ✅ P1 — Consolidação do cliente HTTP
+- **Branch:** `worktree-agent-a304ec88102467fb2`
+- **Worktree:** `.claude/worktrees/agent-a304ec88102467fb2`
+- **Commits:** `bb0ab98` (módulo), `fd1442c` (ui-grid), `58fcb44` (files), `a937ba4` (admin)
+- **Novo módulo:** `lib/api/http-client.ts` exportando `apiFetch`, `parseEnvelope`, `ApiClientError`
+- **Migração:** 3 consumers (`components/ui-grid/api.ts`, `components/files/api.ts`, `components/admin/api.ts`) — API pública preservada via re-export
+- **Testes:** 74/74 ✅ (9 novos)
+- **Trade-off:** branch de aborto externo do admin agora distingue entre timeout interno e abort externo (mais correto, sem caller-impact)
+
+### ✅ P1 — Hardening price-contexts
+- **Branch:** `worktree-agent-af0d32ac346c988ef`
+- **Worktree:** `.claude/worktrees/agent-af0d32ac346c988ef`
+- **Commits:** `5aa673a` (policy), `54f700f` (refactor), `4da4268` (testes)
+- **Allow-list:** `carros.preco_original` + `anuncios.valor_anuncio` em `lib/domain/price-contexts/policy.ts`
+- **Role mínimo:** `GERENTE` (alinhado com `/api/v1/auditoria`)
+- **`any` removidos:** 2 (em ambas as rotas), tipados via `SupabaseClient<Database>`
+- **Testes:** 81/81 ✅ (16 novos)
+- **Risco residual:** UI em `app/price-contexts/page.tsx` ainda aceita query params livres — precisará de error UX amigável; middleware não filtra role no edge (descobre só após fetch)
+
+### ✅ P1 — Quebra do HolisticSheet
+- **Branch:** `refactor/holistic-sheet-monolith`
+- **Worktree:** `.claude/worktrees/refactor-holistic-sheet`
+- **Agente:** Codex gpt-5.5 xhigh (291k tokens; 2 falsas-partidas de stdin antes de funcionar com `< /dev/null`)
+- **Commits:** `bdaa948` (stored state), `8b312d8` (car form state), `1c586e4` (price context dialogs), `4c38406` (anuncio insights)
+- **Hooks extraídos** em `components/ui-grid/hooks/`:
+  - `useGridStoredState.ts` (118 linhas) — localStorage/persistência
+  - `useGridCarFormState.ts` (131 linhas) — estado do form de carro
+  - `useGridPriceContextDialogs.ts` (143 linhas) — diálogos de contexto de preço
+  - `useGridAnuncioInsights.ts` (173 linhas) — insights de anúncio
+- **`holistic-sheet.tsx`:** 7.402 → 7.176 linhas (-506 locais, +705 em hooks dedicados — modularidade, não compressão)
+- **Testes:** 65/65 ✅, `tsc --noEmit` limpo após cada extração
+- **Parada deliberada:** Codex parou antes de seleção-por-teclado, drawers e edição inline — cortes que cruzam refs/layout/mutações e exigem mais cuidado. Documentado no commit `4c38406`.
+
+## Caveat de processo
+
+Os 3 sub-agentes Claude bootaram a partir de `main`, então leram a versão **antiga** do AGENTS.md (47 linhas). O AGENTS.md Karpathy reescrito vive em `sharp-joliot-221f0d`. Em ordem de merge: **landar AGENTS.md primeiro** para que agentes futuros tenham contexto rico.
+
+## Próximos passos
+
+1. Aguardar Codex completar
+2. Validar cada branch: `npm ci && npm run lint && npm run test:unit && npm run build`
+3. Decidir ordem de merge (sugestão: AGENTS.md → P0 errors → http-client → price-contexts → HolisticSheet)
+4. Wave 2: FileManagerWorkspace, PlaygroundWorkspace, validação Zod, CI expandido


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 1
- Escopo tocado: AGENTS.md, work records

## Resumo
Reescreve `AGENTS.md` aplicando o método Karpathy: invariantes não-óbvios em primeiro lugar, pares DO/DON'T com exemplos concretos de código, lista de arquivos canônicos por cenário comum, e seção explícita de Gotchas extraída da auditoria gpt-5.5 xhigh do repo.

Adiciona também work record para a Wave 1 da orquestração de refactor (4 PRs irmãs):
- `refactor/sanitize-error-details` (P0 segurança)
- `refactor/shared-http-client` (P1 consolidação)
- `security/price-contexts-allow-list` (P1 segurança)
- `refactor/holistic-sheet-monolith` (P1 quebra de monólito)

## Metas mínimas de qualidade
### Linhas antes/depois
- AGENTS.md antes: 47
- AGENTS.md depois: 215
- Delta: +168 (mais denso e acionável)
- Work record novo: +94

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0 (markdown apenas)

### Evidência de testes
- [x] N/A — somente documentação
- Validação: revisão visual

### Tempo de review
- Tempo total estimado: 10 min
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 1
- [x] Segurança validada (não toca código)
- [x] Regressão visual validada
- [x] Performance validada (N/A)

## Observações finais
- Riscos residuais: agentes futuros que clonarem branches antigas verão a versão antiga até esse PR landar — recomendado fazer merge antes das demais PRs da Wave 1
- Plano de rollback: `git revert 68a782a`
