### PR TITLE
fix(api): omit error details from production responses

### DIFF
--- a/lib/api/__tests__/response.test.ts
+++ b/lib/api/__tests__/response.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { apiError } from "@/lib/api/response";
+
+type ApiErrorBody = {
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+  request_id: string;
+};
+
+const REQUEST_ID = "req-test-123";
+const SUPABASE_LIKE_DETAILS = {
+  code: "23505",
+  message: "duplicate key value violates unique constraint",
+  details: 'Key (id)=(1) already exists.',
+  hint: "psql hint",
+  schema: "public",
+  table: "carros"
+};
+
+async function readBody(response: Response): Promise<ApiErrorBody> {
+  return (await response.json()) as ApiErrorBody;
+}
+
+describe("apiError", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe("in development", () => {
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "development");
+    });
+
+    it("includes details in the response body", async () => {
+      const response = apiError(
+        REQUEST_ID,
+        500,
+        "TEST_CODE",
+        "Mensagem de teste.",
+        SUPABASE_LIKE_DETAILS
+      );
+
+      expect(response.status).toBe(500);
+      const body = await readBody(response);
+      expect(body.error.code).toBe("TEST_CODE");
+      expect(body.error.message).toBe("Mensagem de teste.");
+      expect(body.error.details).toEqual(SUPABASE_LIKE_DETAILS);
+      expect(body.request_id).toBe(REQUEST_ID);
+    });
+
+    it("omits details when none is passed", async () => {
+      const response = apiError(REQUEST_ID, 400, "VALIDATION", "Invalid input.");
+      const body = await readBody(response);
+      expect(body.error).toEqual({ code: "VALIDATION", message: "Invalid input." });
+      expect(body.error.details).toBeUndefined();
+    });
+  });
+
+  describe("in production", () => {
+    beforeEach(() => {
+      vi.stubEnv("NODE_ENV", "production");
+    });
+
+    it("strips details from the response body", async () => {
+      const response = apiError(
+        REQUEST_ID,
+        500,
+        "TEST_CODE",
+        "Mensagem de teste.",
+        SUPABASE_LIKE_DETAILS
+      );
+
+      expect(response.status).toBe(500);
+      const body = await readBody(response);
+      expect(body.error.code).toBe("TEST_CODE");
+      expect(body.error.message).toBe("Mensagem de teste.");
+      expect(body.error.details).toBeUndefined();
+      expect(body.request_id).toBe(REQUEST_ID);
+    });
+
+    it("does not leak Supabase-shaped objects via JSON serialization", async () => {
+      const response = apiError(
+        REQUEST_ID,
+        400,
+        "PG_ERROR",
+        "Erro de banco.",
+        SUPABASE_LIKE_DETAILS
+      );
+
+      const raw = await response.text();
+      expect(raw).not.toContain("23505");
+      expect(raw).not.toContain("duplicate key value");
+      expect(raw).not.toContain("public");
+      expect(raw).toContain("PG_ERROR");
+      expect(raw).toContain(REQUEST_ID);
+    });
+  });
+});

--- a/lib/api/execute.ts
+++ b/lib/api/execute.ts
@@ -29,9 +29,11 @@ export async function executeApi<T>(req: NextRequest, handler: Handler<T>) {
     return await handler({ req, requestId, supabase });
   } catch (error) {
     if (error instanceof ApiHttpError) {
+      console.error(`[${error.code}]`, { requestId, error });
       return apiError(requestId, error.status, error.code, error.message, error.details);
     }
 
+    console.error("[INTERNAL_ERROR]", { requestId, error });
     return apiError(requestId, 500, "INTERNAL_ERROR", "Erro interno nao tratado.");
   }
 }

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -5,6 +5,19 @@ export function apiOk<T>(data: T, meta: ApiSuccessMeta) {
   return NextResponse.json({ data, meta });
 }
 
+type ApiErrorBody = {
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+  request_id: string;
+};
+
+function isProductionEnv(): boolean {
+  return process.env.NODE_ENV === "production";
+}
+
 export function apiError(
   requestId: string,
   status: number,
@@ -12,15 +25,16 @@ export function apiError(
   message: string,
   details?: unknown
 ) {
-  return NextResponse.json(
-    {
-      error: {
-        code,
-        message,
-        details
-      },
-      request_id: requestId
-    },
-    { status }
-  );
+  const errorPayload: ApiErrorBody["error"] = { code, message };
+
+  if (details !== undefined && !isProductionEnv()) {
+    errorPayload.details = details;
+  }
+
+  const body: ApiErrorBody = {
+    error: errorPayload,
+    request_id: requestId
+  };
+
+  return NextResponse.json(body, { status });
 }


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 1 (segurança)
- Escopo tocado: lib/api/response.ts, lib/api/execute.ts

## Resumo
**P0 da auditoria gpt-5.5 xhigh.** O helper `apiError` devolvia o objeto `details` ao cliente, e ~150 callsites passavam erros Supabase crus (`PGError` com `code`/`hint`/`message` interno). Em produção isso vaza schema/SQL.

Mudança central:
- `lib/api/response.ts` filtra `details` quando `NODE_ENV === "production"`; assinatura pública preservada
- `lib/api/execute.ts` adiciona `console.error("[CODE]", { requestId, error })` antes do throw

Por ser fix na serialização, **os ~150 callsites já estão protegidos** sem precisar refactor por callsite (esse fica para PR de cleanup futuro).

## Metas mínimas de qualidade
### Linhas antes/depois
- `lib/api/response.ts`: ~25 → ~45
- `lib/api/execute.ts`: ~50 → ~60
- Novo: `lib/api/__tests__/response.test.ts` (4 testes)

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0
- `npx tsc --noEmit`: limpo

### Evidência de testes
- [x] Testes unitários: **69/69 passaram** (4 novos)
- [x] E2E: N/A — fix em serialização de erro não muda fluxo de UI
- Comandos:
  ```txt
  npm run test:unit  → 69/69 ✅
  npx tsc --noEmit   → exit 0
  ```

### Tempo de review
- Tempo total estimado: 15 min
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 1
- [x] Segurança validada (objetivo da PR)
- [x] Regressão visual validada (não toca UI)
- [x] Performance validada (apenas console.error a mais no caminho de erro)

## Observações finais
- Riscos residuais:
  - Logging duplicado possível em callsites que já fazem `console.error` local — auditar em PR separada
  - `error.message` ainda pode ser parcialmente exposto via `message` do helper — fora de escopo
  - ~150 callsites continuam passando erro Supabase cru como `details`; protegidos pela serialização, mas refactor explícito (`{ pgCode: error.code }`) recomendado em PR futura
- Plano de rollback: `git revert 0824d86 eb4b184`

Commits: `eb4b184` (testes), `0824d86` (filtro)
