### PR TITLE
refactor(api): consolidate duplicated http client into shared module

### DIFF
--- a/components/admin/api.ts
+++ b/components/admin/api.ts
@@ -1,6 +1,6 @@
-import { ApiClientError, buildRequestHeaders } from "@/components/ui-grid/api";
+import { buildRequestHeaders } from "@/components/ui-grid/api";
 import type { RequestAuth } from "@/components/ui-grid/types";
-import type { ApiEnvelope } from "@/lib/core/types";
+import { apiFetch, parseEnvelope } from "@/lib/api/http-client";
 
 const ADMIN_API_TIMEOUT_MS = 15_000;
 
@@ -32,41 +32,15 @@ export type AdminUsersPayload = {
   };
 };
 
-async function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit) {
-  const controller = new AbortController();
-  const timeout = window.setTimeout(() => controller.abort(), ADMIN_API_TIMEOUT_MS);
-
-  try {
-    return await fetch(input, {
-      ...init,
-      signal: controller.signal
-    });
-  } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
-      throw new ApiClientError("Tempo limite excedido ao comunicar com a API de administracao.", {
-        status: 408,
-        code: "REQUEST_TIMEOUT"
-      });
-    }
-
-    throw error;
-  } finally {
-    window.clearTimeout(timeout);
-  }
+function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit) {
+  return apiFetch(input, init, {
+    timeoutMs: ADMIN_API_TIMEOUT_MS,
+    timeoutMessage: "Tempo limite excedido ao comunicar com a API de administracao."
+  });
 }
 
-async function parseApi<T>(response: Response): Promise<T> {
-  const json = (await response.json()) as ApiEnvelope<T>;
-
-  if (!response.ok || json.error) {
-    throw new ApiClientError(json.error?.message ?? "Falha na API administrativa.", {
-      status: response.status,
-      code: json.error?.code,
-      details: json.error?.details
-    });
-  }
-
-  return json.data;
+function parseApi<T>(response: Response): Promise<T> {
+  return parseEnvelope<T>(response, { fallbackErrorMessage: "Falha na API administrativa." });
 }
 
 export async function fetchAdminUsers(requestAuth: RequestAuth) {

--- a/components/files/api.ts
+++ b/components/files/api.ts
@@ -1,4 +1,4 @@
-import { ApiClientError, buildAuthHeaders } from "@/components/ui-grid/api";
+import { buildAuthHeaders } from "@/components/ui-grid/api";
 import type { RequestAuth } from "@/components/ui-grid/types";
 import type {
   FileAutomationRepositoryKey,
@@ -7,69 +7,30 @@ import type {
   FileFolderSummary,
   VehicleFolderDisplayField
 } from "@/components/files/types";
-import type { ApiEnvelope } from "@/lib/core/types";
+import { apiFetch, parseEnvelope } from "@/lib/api/http-client";
 
 const DEFAULT_API_REQUEST_TIMEOUT_MS = 30_000;
 const FILE_UPLOAD_REQUEST_TIMEOUT_MS = 180_000;
 
-async function fetchWithTimeout(
+function fetchWithTimeout(
   input: RequestInfo | URL,
   init?: RequestInit,
-  timeoutMs = DEFAULT_API_REQUEST_TIMEOUT_MS,
+  timeoutMs: number = DEFAULT_API_REQUEST_TIMEOUT_MS,
   externalSignal?: AbortSignal
 ) {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), timeoutMs);
-
-  try {
-    return await fetch(input, {
+  return apiFetch(
+    input,
+    {
       cache: "no-store",
       ...init,
-      signal: externalSignal ?? controller.signal
-    });
-  } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
-      throw new ApiClientError("Tempo limite excedido ao comunicar com a API.", {
-        status: 408,
-        code: "REQUEST_TIMEOUT"
-      });
-    }
-
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-  }
+      signal: externalSignal ?? init?.signal
+    },
+    { timeoutMs }
+  );
 }
 
-async function parseApi<T>(response: Response): Promise<T> {
-  const contentType = response.headers.get("content-type") || "";
-  let json: ApiEnvelope<T> | null = null;
-
-  if (contentType.includes("application/json")) {
-    json = (await response.json()) as ApiEnvelope<T>;
-  } else {
-    // Fallback: try JSON, else read text to surface server/proxy errors like 413/HTML
-    try {
-      json = (await response.clone().json()) as ApiEnvelope<T>;
-    } catch {
-      const text = await response.text();
-      throw new ApiClientError(text.slice(0, 300) || "Falha na operacao da API.", {
-        status: response.status,
-        code: String(response.status || "HTTP_ERROR"),
-        details: { contentType }
-      });
-    }
-  }
-
-  if (!response.ok || json.error) {
-    throw new ApiClientError(json.error?.message ?? "Falha na operacao da API", {
-      status: response.status,
-      code: json.error?.code,
-      details: json.error?.details
-    });
-  }
-
-  return json.data;
+function parseApi<T>(response: Response): Promise<T> {
+  return parseEnvelope<T>(response, { fallbackErrorMessage: "Falha na operacao da API" });
 }
 
 export async function fetchFileFolders(requestAuth: RequestAuth) {

--- a/components/ui-grid/api.ts
+++ b/components/ui-grid/api.ts
@@ -9,7 +9,9 @@ import type {
   SheetKey,
   SortRule
 } from "@/components/ui-grid/types";
-import type { ApiEnvelope } from "@/lib/core/types";
+import { ApiClientError, apiFetch, parseEnvelope } from "@/lib/api/http-client";
+
+export { ApiClientError } from "@/lib/api/http-client";
 
 export type PlateLookupFipe = {
   codigo_fipe: string | null;
@@ -94,20 +96,6 @@ export type AuditDashboardPayload = {
 const API_REQUEST_TIMEOUT_MS = 15_000;
 const GRID_INSIGHTS_REQUEST_TIMEOUT_MS = 30_000;
 
-export class ApiClientError extends Error {
-  status: number;
-  code?: string;
-  details?: unknown;
-
-  constructor(message: string, options?: { status?: number; code?: string; details?: unknown }) {
-    super(message);
-    this.name = "ApiClientError";
-    this.status = options?.status ?? 500;
-    this.code = options?.code;
-    this.details = options?.details;
-  }
-}
-
 function buildDevHeaders(role: Role) {
   return {
     "x-user-role": role,
@@ -137,67 +125,16 @@ export function buildRequestHeaders(auth: RequestAuth) {
   };
 }
 
-async function fetchWithTimeout(input: RequestInfo | URL, init?: RequestInit, timeoutMs = API_REQUEST_TIMEOUT_MS) {
-  const controller = new AbortController();
-  let timedOut = false;
-  const timeout = setTimeout(() => {
-    timedOut = true;
-    controller.abort();
-  }, timeoutMs);
-  const externalSignal = init?.signal;
-  const abortFromExternalSignal = () => controller.abort();
-
-  if (externalSignal) {
-    if (externalSignal.aborted) {
-      controller.abort();
-    } else {
-      externalSignal.addEventListener("abort", abortFromExternalSignal, { once: true });
-    }
-  }
-
-  try {
-    return await fetch(input, {
-      ...init,
-      signal: controller.signal
-    });
-  } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError" && timedOut) {
-      throw new ApiClientError("Tempo limite excedido ao comunicar com a API.", {
-        status: 408,
-        code: "REQUEST_TIMEOUT"
-      });
-    }
-
-    throw error;
-  } finally {
-    clearTimeout(timeout);
-    externalSignal?.removeEventListener("abort", abortFromExternalSignal);
-  }
+function fetchWithTimeout(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  timeoutMs: number = API_REQUEST_TIMEOUT_MS
+) {
+  return apiFetch(input, init, { timeoutMs });
 }
 
-async function parseApi<T>(response: Response): Promise<T> {
-  const raw = await response.text();
-  let json: ApiEnvelope<T>;
-
-  try {
-    json = JSON.parse(raw) as ApiEnvelope<T>;
-  } catch {
-    throw new ApiClientError("Resposta invalida da API. Verifique se o servidor retornou erro HTML ou cache invalido.", {
-      status: response.status,
-      code: "API_INVALID_JSON",
-      details: raw.slice(0, 500)
-    });
-  }
-
-  if (!response.ok || json.error) {
-    throw new ApiClientError(json.error?.message ?? "Falha na operacao da API", {
-      status: response.status,
-      code: json.error?.code,
-      details: json.error?.details
-    });
-  }
-
-  return json.data;
+function parseApi<T>(response: Response): Promise<T> {
+  return parseEnvelope<T>(response, { fallbackErrorMessage: "Falha na operacao da API" });
 }
 
 export async function fetchSheetRows(params: {

--- a/lib/api/__tests__/http-client.test.ts
+++ b/lib/api/__tests__/http-client.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError, apiFetch, parseEnvelope } from "@/lib/api/http-client";
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  globalThis.fetch = originalFetch;
+});
+
+function buildJsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { "content-type": "application/json", ...(init?.headers ?? {}) }
+  });
+}
+
+describe("apiFetch", () => {
+  it("throws REQUEST_TIMEOUT after the configured timeout fires", async () => {
+    globalThis.fetch = vi.fn((_input, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const promise = apiFetch("/api/v1/sample", {}, { timeoutMs: 50 });
+    const expectation = expect(promise).rejects.toBeInstanceOf(ApiClientError);
+
+    await vi.advanceTimersByTimeAsync(60);
+    await expectation;
+
+    await promise.catch((error: unknown) => {
+      expect(error).toBeInstanceOf(ApiClientError);
+      const err = error as ApiClientError;
+      expect(err.status).toBe(408);
+      expect(err.code).toBe("REQUEST_TIMEOUT");
+    });
+  });
+
+  it("rethrows external aborts without converting them to REQUEST_TIMEOUT", async () => {
+    globalThis.fetch = vi.fn((_input, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    }) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    const promise = apiFetch("/api/v1/sample", { signal: controller.signal }, { timeoutMs: 5_000 });
+
+    controller.abort();
+
+    await expect(promise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  it("returns the underlying response when the request completes in time", async () => {
+    const response = buildJsonResponse({ data: { ok: true } });
+    globalThis.fetch = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+
+    const result = await apiFetch("/api/v1/sample");
+    expect(result).toBe(response);
+  });
+});
+
+describe("parseEnvelope", () => {
+  it("returns data when the envelope is successful", async () => {
+    const response = buildJsonResponse({ data: { id: "abc" }, meta: { page: 1 } });
+    const data = await parseEnvelope<{ id: string }>(response);
+    expect(data).toEqual({ id: "abc" });
+  });
+
+  it("preserves meta-shaped envelopes by ignoring meta on success", async () => {
+    const response = buildJsonResponse({
+      data: { rows: [1, 2, 3] },
+      meta: { page: 2, pageSize: 50, total: 120, totalPages: 3 }
+    });
+    const data = await parseEnvelope<{ rows: number[] }>(response);
+    expect(data.rows).toEqual([1, 2, 3]);
+  });
+
+  it("throws ApiClientError with code/message/details when error envelope is present", async () => {
+    const response = buildJsonResponse(
+      {
+        data: null,
+        error: { code: "VALIDATION_FAILED", message: "Campo invalido", details: { field: "nome" } }
+      },
+      { status: 400 }
+    );
+
+    await expect(parseEnvelope(response)).rejects.toMatchObject({
+      name: "ApiClientError",
+      status: 400,
+      code: "VALIDATION_FAILED",
+      message: "Campo invalido",
+      details: { field: "nome" }
+    });
+  });
+
+  it("uses fallback message when error.message is missing", async () => {
+    const response = buildJsonResponse(
+      { data: null, error: { code: "INTERNAL", message: "" } },
+      { status: 500 }
+    );
+
+    await expect(
+      parseEnvelope(response, { fallbackErrorMessage: "Erro generico." })
+    ).rejects.toMatchObject({
+      message: "Erro generico.",
+      status: 500
+    });
+  });
+
+  it("throws API_INVALID_JSON when the body is not JSON", async () => {
+    const response = new Response("<html>500</html>", {
+      status: 502,
+      headers: { "content-type": "text/html" }
+    });
+
+    await expect(parseEnvelope(response)).rejects.toMatchObject({
+      name: "ApiClientError",
+      code: "API_INVALID_JSON",
+      status: 502
+    });
+  });
+
+  it("treats non-2xx JSON without an error block as failure", async () => {
+    const response = buildJsonResponse({ data: null }, { status: 503 });
+    await expect(parseEnvelope(response)).rejects.toMatchObject({
+      name: "ApiClientError",
+      status: 503
+    });
+  });
+});

--- a/lib/api/http-client.ts
+++ b/lib/api/http-client.ts
@@ -1,0 +1,131 @@
+import type { ApiEnvelope, ApiErrorPayload } from "@/lib/core/types/api";
+
+export type { ApiEnvelope, ApiErrorPayload } from "@/lib/core/types/api";
+
+const DEFAULT_API_REQUEST_TIMEOUT_MS = 15_000;
+
+export type ApiClientErrorOptions = {
+  status?: number;
+  code?: string;
+  details?: unknown;
+};
+
+export class ApiClientError extends Error {
+  status: number;
+  code?: string;
+  details?: unknown;
+
+  constructor(message: string, options?: ApiClientErrorOptions) {
+    super(message);
+    this.name = "ApiClientError";
+    this.status = options?.status ?? 500;
+    this.code = options?.code;
+    this.details = options?.details;
+  }
+}
+
+export type ApiFetchOptions = {
+  /** Total time before the request is aborted with `REQUEST_TIMEOUT`. Defaults to 15s. */
+  timeoutMs?: number;
+  /** Message used when the timeout fires. */
+  timeoutMessage?: string;
+};
+
+/**
+ * Wraps `fetch` with an `AbortController`-based timeout. If the caller passes
+ * `init.signal`, the external signal still aborts the request, but only the
+ * internal timeout produces a typed `ApiClientError("REQUEST_TIMEOUT")`; an
+ * external abort is rethrown as-is so callers can detect their own cancellation.
+ */
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+  options?: ApiFetchOptions
+): Promise<Response> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_API_REQUEST_TIMEOUT_MS;
+  const timeoutMessage = options?.timeoutMessage ?? "Tempo limite excedido ao comunicar com a API.";
+
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  const externalSignal = init?.signal ?? undefined;
+  const abortFromExternal = () => controller.abort();
+
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalSignal.addEventListener("abort", abortFromExternal, { once: true });
+    }
+  }
+
+  try {
+    return await fetch(input, {
+      ...init,
+      signal: controller.signal
+    });
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError" && timedOut) {
+      throw new ApiClientError(timeoutMessage, {
+        status: 408,
+        code: "REQUEST_TIMEOUT"
+      });
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+    externalSignal?.removeEventListener("abort", abortFromExternal);
+  }
+}
+
+export type ParseEnvelopeOptions = {
+  /** Fallback message used when the envelope error payload omits `message`. */
+  fallbackErrorMessage?: string;
+  /** Fallback message used when the response body is not valid JSON. */
+  invalidJsonMessage?: string;
+};
+
+/**
+ * Reads a `{ data, meta, error }` envelope and either returns `data` or throws
+ * a typed `ApiClientError`. Treats non-JSON bodies and non-2xx responses as
+ * errors so consumers always get structured failures.
+ */
+export async function parseEnvelope<T>(
+  response: Response,
+  options?: ParseEnvelopeOptions
+): Promise<T> {
+  const fallbackErrorMessage = options?.fallbackErrorMessage ?? "Falha na operacao da API.";
+  const invalidJsonMessage =
+    options?.invalidJsonMessage ??
+    "Resposta invalida da API. Verifique se o servidor retornou erro HTML ou cache invalido.";
+
+  const raw = await response.text();
+
+  let json: ApiEnvelope<T>;
+  try {
+    json = JSON.parse(raw) as ApiEnvelope<T>;
+  } catch {
+    throw new ApiClientError(invalidJsonMessage, {
+      status: response.status,
+      code: "API_INVALID_JSON",
+      details: raw.slice(0, 500)
+    });
+  }
+
+  const errorPayload: ApiErrorPayload | undefined = json?.error;
+  if (!response.ok || errorPayload) {
+    const message = errorPayload?.message;
+    throw new ApiClientError(message && message.length > 0 ? message : fallbackErrorMessage, {
+      status: response.status,
+      code: errorPayload?.code,
+      details: errorPayload?.details
+    });
+  }
+
+  return json.data;
+}


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 2
- Escopo tocado: `lib/api/http-client.ts` (novo), `components/{ui-grid,files,admin}/api.ts`

## Resumo
**P1 da auditoria.** `fetchWithTimeout` / `parseApi` / handling do envelope `{ data, meta, error }` estavam duplicados em 3 arquivos client-side. Consolidados num módulo único em `lib/api/http-client.ts`.

Decisão de localização (`lib/` em vez de `components/shared/`):
- AGENTS.md: lógica reutilizável vai em `lib/`
- `ApiEnvelope` já vivia em `lib/core/types/api.ts`
- Sem dependências de DOM-only APIs (substitui `window.setTimeout` por `setTimeout` global → SSR-safe)

API pública dos 3 consumers (`components/{ui-grid,files,admin}/api.ts`) preservada via re-export — ninguém de fora precisa mudar import.

## Metas mínimas de qualidade
### Linhas antes/depois
- `ui-grid/api.ts`: -74 / +11
- `files/api.ts`: -52 / +13
- `admin/api.ts`: -35 / +9
- Novo: `lib/api/http-client.ts` (~140 linhas) + `http-client.test.ts` (~120 linhas, 9 testes)

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0
- `npx tsc --noEmit`: limpo
- `any` introduzidos: 0

### Evidência de testes
- [x] Testes unitários: **74/74 passaram** (9 novos)
- [x] E2E: recomendado rodar antes do merge — `npm run test:e2e` para garantir que ui-grid/files/admin continuam funcionais
- Comandos:
  ```txt
  npm run test:unit  → 74/74 ✅ (3.3s)
  npx tsc --noEmit   → exit 0
  ```

### Tempo de review
- Tempo total estimado: 25 min
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 2
- [x] Segurança validada (sem mudança de auth)
- [x] Regressão visual validada (consumers preservam API pública)
- [x] Performance validada (apenas refactor estrutural)

## Observações finais
- Riscos residuais:
  - **Mudança de comportamento no admin**: antes capturava QUALQUER `AbortError` como `REQUEST_TIMEOUT`; agora distingue timeout interno (vira `REQUEST_TIMEOUT`) de abort externo (rethrow puro). Mais correto, e admin nunca passou signal externo → caller-impact zero.
  - **`files/api.ts` perdeu o branch `response.clone()` para tentar text fallback**: `parseEnvelope` lê texto uma vez e tenta JSON.parse — comportamento equivalente em superfície, mas `details.contentType` não é mais incluído em erros de JSON inválido. Não localizei consumidor que lesse esse campo.
  - `ApiClientError` continua re-exportada por `components/ui-grid/api.ts` (mesma classe, não duplicação) — migração de imports diretos para `@/lib/api/http-client` fica para PR de cleanup futura.
- Plano de rollback: `git revert a937ba4 58fcb44 fd1442c bb0ab98`

Commits: `bb0ab98` (módulo), `fd1442c` (ui-grid), `58fcb44` (files), `a937ba4` (admin)
