### PR TITLE
security(price-contexts): enforce allow-list and GERENTE role

### DIFF
--- a/app/api/v1/price-contexts/__tests__/route.test.ts
+++ b/app/api/v1/price-contexts/__tests__/route.test.ts
@@ -1,0 +1,189 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fromMock = vi.fn();
+
+vi.mock("@/lib/api/supabase-admin", () => ({
+  getSupabaseAdmin: () => ({ from: fromMock })
+}));
+
+afterEach(() => {
+  fromMock.mockReset();
+});
+
+function buildListQuery(payload: { data: unknown; error: unknown; count: number | null }) {
+  // The route builds a thenable then conditionally chains .eq() onto it.
+  // Mirror that: every method returns the same builder, and awaiting it
+  // resolves to the payload via a `then` implementation.
+  const builder: Record<string, unknown> = {};
+  builder.select = () => builder;
+  builder.order = () => builder;
+  builder.range = () => builder;
+  builder.eq = () => builder;
+  builder.then = (resolve: (value: typeof payload) => unknown) => Promise.resolve(resolve(payload));
+  const from = vi.fn(() => builder);
+  return { from };
+}
+
+function buildLatestQuery(payload: { data: unknown; error: unknown }) {
+  const maybeSingle = vi.fn().mockResolvedValue(payload);
+  const limit = vi.fn(() => ({ maybeSingle }));
+  const order = vi.fn(() => ({ limit }));
+  const eqChain = (): Record<string, unknown> => {
+    const builder: Record<string, unknown> = {};
+    builder.eq = () => builder;
+    builder.order = order;
+    return builder;
+  };
+  const select = vi.fn(() => eqChain());
+  return { from: vi.fn(() => ({ select })) };
+}
+
+function buildRequest(url: string, headers: Record<string, string> = {}) {
+  return new NextRequest(url, { headers });
+}
+
+async function readJson(res: Response): Promise<{ status: number; body: Record<string, unknown> }> {
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe("GET /api/v1/price-contexts", () => {
+  it("returns 403 when role is below GERENTE", async () => {
+    const { GET } = await import("@/app/api/v1/price-contexts/route");
+    const req = buildRequest("http://localhost/api/v1/price-contexts", {
+      "x-user-role": "SECRETARIO",
+      "x-user-id": "u-1"
+    });
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(403);
+    expect((body as { error?: { code?: string } }).error?.code).toBe("FORBIDDEN");
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 PRICE_CONTEXT_INVALID_TARGET when table is off-list", async () => {
+    const { GET } = await import("@/app/api/v1/price-contexts/route");
+    const req = buildRequest("http://localhost/api/v1/price-contexts?table=usuarios_acesso", {
+      "x-user-role": "GERENTE",
+      "x-user-id": "u-1"
+    });
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(400);
+    expect((body as { error?: { code?: string } }).error?.code).toBe("PRICE_CONTEXT_INVALID_TARGET");
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when filtering by column without a table", async () => {
+    const { GET } = await import("@/app/api/v1/price-contexts/route");
+    const req = buildRequest("http://localhost/api/v1/price-contexts?column=preco_original", {
+      "x-user-role": "GERENTE",
+      "x-user-id": "u-1"
+    });
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(400);
+    expect((body as { error?: { code?: string } }).error?.code).toBe("PRICE_CONTEXT_INVALID_TARGET");
+  });
+
+  it("returns 400 when column is off-list for the allowed table", async () => {
+    const { GET } = await import("@/app/api/v1/price-contexts/route");
+    const req = buildRequest(
+      "http://localhost/api/v1/price-contexts?table=carros&column=valor_anuncio",
+      { "x-user-role": "GERENTE", "x-user-id": "u-1" }
+    );
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(400);
+    expect((body as { error?: { code?: string } }).error?.code).toBe("PRICE_CONTEXT_INVALID_TARGET");
+  });
+
+  it("returns 200 with rows for a valid GERENTE request", async () => {
+    const stub = buildListQuery({
+      data: [
+        {
+          id: "ctx-1",
+          table_name: "carros",
+          row_id: "car-1",
+          column_name: "preco_original",
+          old_value: 1,
+          new_value: 2,
+          context: "ajuste",
+          created_by: "u-1",
+          created_at: "2026-05-08T00:00:00Z"
+        }
+      ],
+      error: null,
+      count: 1
+    });
+    fromMock.mockImplementation(stub.from);
+
+    const { GET } = await import("@/app/api/v1/price-contexts/route");
+    const req = buildRequest(
+      "http://localhost/api/v1/price-contexts?table=carros&column=preco_original",
+      { "x-user-role": "GERENTE", "x-user-id": "u-1" }
+    );
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(200);
+    const data = (body as { data?: { rows?: unknown[] } }).data;
+    expect(Array.isArray(data?.rows)).toBe(true);
+    expect(data?.rows).toHaveLength(1);
+    expect(stub.from).toHaveBeenCalledWith("price_change_contexts");
+  });
+});
+
+describe("GET /api/v1/price-contexts/latest", () => {
+  it("returns 403 for VENDEDOR", async () => {
+    const { GET } = await import("@/app/api/v1/price-contexts/latest/route");
+    const req = buildRequest(
+      "http://localhost/api/v1/price-contexts/latest?table=carros&row_id=r&column=preco_original",
+      { "x-user-role": "VENDEDOR", "x-user-id": "u-1" }
+    );
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(403);
+    expect((body as { error?: { code?: string } }).error?.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 PRICE_CONTEXT_INVALID_TARGET for unknown table", async () => {
+    const { GET } = await import("@/app/api/v1/price-contexts/latest/route");
+    const req = buildRequest(
+      "http://localhost/api/v1/price-contexts/latest?table=usuarios_acesso&row_id=r&column=email",
+      { "x-user-role": "GERENTE", "x-user-id": "u-1" }
+    );
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(400);
+    expect((body as { error?: { code?: string } }).error?.code).toBe("PRICE_CONTEXT_INVALID_TARGET");
+  });
+
+  it("returns 200 entry for a valid GERENTE request", async () => {
+    const stub = buildLatestQuery({
+      data: {
+        id: "ctx-9",
+        table_name: "anuncios",
+        row_id: "an-1",
+        column_name: "valor_anuncio",
+        old_value: 1000,
+        new_value: 1500,
+        context: "promo",
+        created_by: "u-1",
+        created_at: "2026-05-08T00:00:00Z"
+      },
+      error: null
+    });
+    fromMock.mockImplementation(stub.from);
+
+    const { GET } = await import("@/app/api/v1/price-contexts/latest/route");
+    const req = buildRequest(
+      "http://localhost/api/v1/price-contexts/latest?table=anuncios&row_id=an-1&column=valor_anuncio",
+      { "x-user-role": "GERENTE", "x-user-id": "u-1" }
+    );
+
+    const { status, body } = await readJson(await GET(req));
+    expect(status).toBe(200);
+    const data = (body as { data?: { entry?: { column_name?: string } } }).data;
+    expect(data?.entry?.column_name).toBe("valor_anuncio");
+  });
+});

--- a/app/api/v1/price-contexts/latest/route.ts
+++ b/app/api/v1/price-contexts/latest/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest } from "next/server";
 import { executeAuthenticatedApi } from "@/lib/api/execute";
+import { requireRole } from "@/lib/api/auth";
 import { ApiHttpError } from "@/lib/api/errors";
 import { apiOk } from "@/lib/api/response";
+import {
+  listAllowedPriceContextTables,
+  validatePriceContextTarget
+} from "@/lib/domain/price-contexts/policy";
 
 export async function GET(req: NextRequest) {
-  return executeAuthenticatedApi(req, async ({ requestId, supabase }) => {
+  return executeAuthenticatedApi(req, async ({ actor, requestId, supabase }) => {
+    requireRole(actor, "GERENTE");
+
     const table = (req.nextUrl.searchParams.get("table") ?? "").trim();
     const rowId = (req.nextUrl.searchParams.get("row_id") ?? "").trim();
     const column = (req.nextUrl.searchParams.get("column") ?? "").trim();
@@ -13,14 +20,29 @@ export async function GET(req: NextRequest) {
       throw new ApiHttpError(400, "MISSING_PARAMS", "Informe table, row_id e column.");
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const client: any = supabase;
-    const { data, error } = await client
+    const validation = validatePriceContextTarget({ table, column });
+    if (!validation.ok) {
+      throw new ApiHttpError(
+        400,
+        "PRICE_CONTEXT_INVALID_TARGET",
+        validation.error.kind === "TABLE_NOT_ALLOWED"
+          ? "Tabela nao permitida para contextos de preco."
+          : "Coluna nao permitida para contextos de preco.",
+        {
+          ...validation.error,
+          allowedTables: listAllowedPriceContextTables()
+        }
+      );
+    }
+
+    const { data, error } = await supabase
       .from("price_change_contexts")
-      .select("id, table_name, row_id, column_name, old_value, new_value, context, created_by, created_at")
-      .eq("table_name", table)
+      .select(
+        "id, table_name, row_id, column_name, old_value, new_value, context, created_by, created_at"
+      )
+      .eq("table_name", validation.target.table)
       .eq("row_id", rowId)
-      .eq("column_name", column)
+      .eq("column_name", validation.target.column)
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -30,4 +52,3 @@ export async function GET(req: NextRequest) {
     return apiOk({ entry: data ?? null }, { request_id: requestId });
   });
 }
-

--- a/app/api/v1/price-contexts/route.ts
+++ b/app/api/v1/price-contexts/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest } from "next/server";
 import { executeAuthenticatedApi } from "@/lib/api/execute";
+import { requireRole } from "@/lib/api/auth";
 import { ApiHttpError } from "@/lib/api/errors";
 import { apiOk } from "@/lib/api/response";
+import {
+  isAllowedPriceContextColumn,
+  isAllowedPriceContextTable,
+  listAllowedPriceContextTables,
+  type PriceContextTableName
+} from "@/lib/domain/price-contexts/policy";
 
 export async function GET(req: NextRequest) {
-  return executeAuthenticatedApi(req, async ({ requestId, supabase }) => {
+  return executeAuthenticatedApi(req, async ({ actor, requestId, supabase }) => {
+    requireRole(actor, "GERENTE");
+
     const table = (req.nextUrl.searchParams.get("table") ?? "").trim();
     const rowId = (req.nextUrl.searchParams.get("row_id") ?? "").trim();
     const column = (req.nextUrl.searchParams.get("column") ?? "").trim();
@@ -13,17 +22,48 @@ export async function GET(req: NextRequest) {
     const from = (page - 1) * pageSize;
     const to = from + pageSize - 1;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const client: any = supabase;
-    let query = client
+    let validatedTable: PriceContextTableName | null = null;
+    if (table) {
+      if (!isAllowedPriceContextTable(table)) {
+        throw new ApiHttpError(
+          400,
+          "PRICE_CONTEXT_INVALID_TARGET",
+          "Tabela nao permitida para contextos de preco.",
+          { table, allowedTables: listAllowedPriceContextTables() }
+        );
+      }
+      validatedTable = table;
+    }
+
+    if (column) {
+      if (!validatedTable) {
+        throw new ApiHttpError(
+          400,
+          "PRICE_CONTEXT_INVALID_TARGET",
+          "Informe a tabela ao filtrar por coluna.",
+          { column }
+        );
+      }
+      if (!isAllowedPriceContextColumn(validatedTable, column)) {
+        throw new ApiHttpError(
+          400,
+          "PRICE_CONTEXT_INVALID_TARGET",
+          "Coluna nao permitida para contextos de preco.",
+          { table: validatedTable, column }
+        );
+      }
+    }
+
+    let query = supabase
       .from("price_change_contexts")
-      .select("id, table_name, row_id, column_name, old_value, new_value, context, created_by, created_at", {
-        count: "exact"
-      })
+      .select(
+        "id, table_name, row_id, column_name, old_value, new_value, context, created_by, created_at",
+        { count: "exact" }
+      )
       .order("created_at", { ascending: false })
       .range(from, to);
 
-    if (table) query = query.eq("table_name", table);
+    if (validatedTable) query = query.eq("table_name", validatedTable);
     if (rowId) query = query.eq("row_id", rowId);
     if (column) query = query.eq("column_name", column);
 
@@ -41,4 +81,3 @@ export async function GET(req: NextRequest) {
     );
   });
 }
-

--- a/lib/domain/price-contexts/__tests__/policy.test.ts
+++ b/lib/domain/price-contexts/__tests__/policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  PRICE_CONTEXT_TABLE_POLICY,
+  isAllowedPriceContextColumn,
+  isAllowedPriceContextTable,
+  listAllowedPriceContextTables,
+  validatePriceContextTarget
+} from "@/lib/domain/price-contexts/policy";
+
+describe("price-contexts policy allow-list", () => {
+  it("exposes only the auditable price tables", () => {
+    expect(listAllowedPriceContextTables().slice().sort()).toEqual(["anuncios", "carros"]);
+  });
+
+  it("locks columns to the writers in carros/anuncios services", () => {
+    expect(PRICE_CONTEXT_TABLE_POLICY.carros).toEqual(["preco_original"]);
+    expect(PRICE_CONTEXT_TABLE_POLICY.anuncios).toEqual(["valor_anuncio"]);
+  });
+
+  it("rejects unknown tables", () => {
+    expect(isAllowedPriceContextTable("usuarios_acesso")).toBe(false);
+    expect(isAllowedPriceContextTable("price_change_contexts")).toBe(false);
+    expect(isAllowedPriceContextTable("")).toBe(false);
+  });
+
+  it("accepts known tables", () => {
+    expect(isAllowedPriceContextTable("carros")).toBe(true);
+    expect(isAllowedPriceContextTable("anuncios")).toBe(true);
+  });
+
+  it("rejects columns not paired with their table", () => {
+    // valor_anuncio belongs to anuncios, not carros
+    expect(isAllowedPriceContextColumn("carros", "valor_anuncio")).toBe(false);
+    expect(isAllowedPriceContextColumn("anuncios", "preco_original")).toBe(false);
+  });
+
+  it("validates a happy-path target", () => {
+    const result = validatePriceContextTarget({ table: "carros", column: "preco_original" });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.target).toEqual({ table: "carros", column: "preco_original" });
+    }
+  });
+
+  it("returns TABLE_NOT_ALLOWED for foreign tables", () => {
+    const result = validatePriceContextTarget({ table: "usuarios_acesso", column: "email" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("TABLE_NOT_ALLOWED");
+    }
+  });
+
+  it("returns COLUMN_NOT_ALLOWED for off-list columns", () => {
+    const result = validatePriceContextTarget({ table: "carros", column: "placa" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.kind).toBe("COLUMN_NOT_ALLOWED");
+    }
+  });
+});

--- a/lib/domain/price-contexts/policy.ts
+++ b/lib/domain/price-contexts/policy.ts
@@ -1,0 +1,61 @@
+import type { TableName } from "@/lib/domain/db";
+
+/**
+ * Allow-list of (table, column) pairs whose price-change context entries the
+ * `price-contexts` API may read or filter on.
+ *
+ * Mirror in real domain code: see `lib/domain/carros/service.ts` and
+ * `lib/domain/anuncios/service.ts`, which are the only writers of
+ * `price_change_contexts`. If a new price column starts being audited, add it
+ * here too — otherwise the new entries become invisible to the audit UI.
+ */
+export type PriceContextTableName = Extract<TableName, "carros" | "anuncios">;
+
+export const PRICE_CONTEXT_TABLE_POLICY: Record<PriceContextTableName, ReadonlyArray<string>> = {
+  carros: ["preco_original"],
+  anuncios: ["valor_anuncio"]
+};
+
+const TABLE_NAMES = Object.keys(PRICE_CONTEXT_TABLE_POLICY) as PriceContextTableName[];
+
+export function isAllowedPriceContextTable(table: string): table is PriceContextTableName {
+  return (TABLE_NAMES as string[]).includes(table);
+}
+
+export function isAllowedPriceContextColumn(table: PriceContextTableName, column: string) {
+  return PRICE_CONTEXT_TABLE_POLICY[table].includes(column);
+}
+
+export function listAllowedPriceContextTables(): ReadonlyArray<PriceContextTableName> {
+  return TABLE_NAMES;
+}
+
+export type PriceContextTarget = {
+  table: PriceContextTableName;
+  column: string;
+};
+
+export type PriceContextValidationError =
+  | { kind: "TABLE_NOT_ALLOWED"; table: string }
+  | { kind: "COLUMN_NOT_ALLOWED"; table: PriceContextTableName; column: string };
+
+/**
+ * Validates a (table, column) pair against the allow-list. Both inputs must be
+ * present together — partial filters (table without column) are accepted by
+ * passing an empty `column` string (only the table is then validated).
+ */
+export function validatePriceContextTarget(input: {
+  table: string;
+  column: string;
+}): { ok: true; target: PriceContextTarget } | { ok: false; error: PriceContextValidationError } {
+  if (!isAllowedPriceContextTable(input.table)) {
+    return { ok: false, error: { kind: "TABLE_NOT_ALLOWED", table: input.table } };
+  }
+  if (!isAllowedPriceContextColumn(input.table, input.column)) {
+    return {
+      ok: false,
+      error: { kind: "COLUMN_NOT_ALLOWED", table: input.table, column: input.column }
+    };
+  }
+  return { ok: true, target: { table: input.table, column: input.column } };
+}


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 1 (segurança)
- Escopo tocado: `app/api/v1/price-contexts/**`, `lib/domain/price-contexts/`

## Resumo
**P1 de segurança da auditoria.** A rota expõe trilha de auditoria de alterações de preço; antes:
- Aceitava `table` / `row_id` / `column` livres do cliente (sem allow-list)
- Usava `const client: any` (escapava do TS strict)
- Não tinha `requireRole` explícito

Mudanças:
- Nova policy em `lib/domain/price-contexts/policy.ts` — allow-list `carros.preco_original` + `anuncios.valor_anuncio` (derivado dos únicos writers reais de `price_change_contexts`)
- `requireRole(actor, "GERENTE")` — alinhado com `/api/v1/auditoria` (que também expõe trilha histórica)
- 2 `any` removidos das rotas → tipados via `SupabaseClient<Database>` herdado de `executeAuthenticatedApi`

## Metas mínimas de qualidade
### Linhas antes/depois
- `app/api/v1/price-contexts/route.ts`: refactor (`any` → tipado)
- `app/api/v1/price-contexts/latest/route.ts`: refactor (`any` → tipado)
- Novos:
  - `lib/domain/price-contexts/policy.ts`
  - `lib/domain/price-contexts/__tests__/policy.test.ts`
  - `app/api/v1/price-contexts/__tests__/route.test.ts`

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0
- `npx tsc --noEmit`: limpo
- `any` removidos: 2 — zero introduzidos

### Evidência de testes
- [x] Testes unitários: **81/81 passaram** (16 novos)
- [x] E2E: N/A — testes unitários cobrem allow-list, role gate, payload válido
- Comandos:
  ```txt
  npm run test:unit  → 81/81 ✅ (3.7s)
  npx tsc --noEmit   → exit 0
  ```

### Tempo de review
- Tempo total estimado: 20 min
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 1
- [x] Segurança validada (objetivo da PR)
- [x] Regressão visual validada (não toca UI; clientes legítimos passam pela allow-list)
- [x] Performance validada (1 verificação extra antes do query)

## Exemplos de payload

✅ Aceito (200):
```http
GET /api/v1/price-contexts/latest?table=carros&row_id=car-1&column=preco_original
Authorization: Bearer <gerente>
→ 200 { data: { entry: { ... } }, meta: { request_id } }
```

❌ Rejeitado (400 — tabela fora da allow-list):
```http
GET /api/v1/price-contexts?table=usuarios_acesso
→ 400 { error: { code: "PRICE_CONTEXT_INVALID_TARGET", details: { allowedTables: [...] } } }
```

❌ Rejeitado (403 — role insuficiente):
```http
GET /api/v1/price-contexts  (role=SECRETARIO)
→ 403 { error: { code: "FORBIDDEN", message: "Este endpoint exige perfil GERENTE." } }
```

## Observações finais
- Riscos residuais:
  - UI em `app/price-contexts/page.tsx` ainda aceita query params livres; agora a API rejeita tabelas estranhas, mas a UI mostra erro genérico — propor UX amigável em PR separada
  - `middleware.ts` autentica mas não filtra role no edge — VENDEDOR/SECRETARIO entram na page e só descobrem 403 após o fetch
  - `row_id` continua string livre, mas alimenta apenas `.eq("row_id", ...)` (parametrizado) — risco baixo
- Plano de rollback: `git revert 4da4268 54f700f 5aa673a`

Commits: `5aa673a` (policy), `54f700f` (refactor), `4da4268` (testes)
