### PR TITLE
refactor(files): extract 5 hooks from FileManagerWorkspace

### DIFF
--- a/components/files/file-manager-workspace.tsx
+++ b/components/files/file-manager-workspace.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/files/folder-tree";
 import { useFileManagerFolderData } from "@/components/files/hooks/use-file-manager-folder-data";
 import { useFileManagerFolderFormState } from "@/components/files/hooks/use-file-manager-folder-form-state";
+import { useFileManagerNavigationState } from "@/components/files/hooks/use-file-manager-navigation-state";
 import { useFileManagerPreviewText } from "@/components/files/hooks/use-file-manager-preview-text";
 import { useFileManagerQueryState } from "@/components/files/hooks/use-file-manager-query-state";
 import { useFileSelection } from "@/components/files/hooks/use-file-selection";
@@ -74,8 +75,6 @@ type FileManagerWorkspaceProps = {
 };
 
 type ViewMode = "compact" | "medium" | "large";
-
-type MobileFilesSection = "browser" | "preview" | "manage";
 
 type ExplorerItemSelection =
   | { type: "folder"; id: string }
@@ -238,23 +237,6 @@ export function FileManagerWorkspace({
     setError,
   });
 
-  const {
-    enqueueUploadFiles,
-    pendingUploads,
-    queuedUploadsCount,
-  } = useFileUploadFlow({
-    accessToken,
-    devRole,
-    getActiveFolderId,
-    loadActiveFolder,
-    loadFolders,
-    onNavigateToFolder: (folderId) => {
-      navigateToFolder(folderId);
-    },
-    setError,
-    setInfo,
-  });
-
   const [automationPanelOpen, setAutomationPanelOpen] = useState(false);
 
   const [automationSettings, setAutomationSettings] =
@@ -320,17 +302,6 @@ export function FileManagerWorkspace({
 
   const [activeUploadDropzone, setActiveUploadDropzone] = useState(false);
 
-  const [mobileSection, setMobileSection] =
-    useState<MobileFilesSection>("browser");
-
-  const [mobileExplorerCollapsed, setMobileExplorerCollapsed] = useState(true);
-
-  const [expandedFolderIds, setExpandedFolderIds] = useState<Set<string>>(
-    () => new Set(),
-  );
-
-  const uploadBusy = pendingUploads.length > 0 || queuedUploadsCount > 0;
-
   const folderTree = useMemo(() => buildFolderTree(folders), [folders]);
 
   const rootFolders = folderTree;
@@ -343,10 +314,6 @@ export function FileManagerWorkspace({
   const rootFolderOptions = useMemo(
     () => rootFolders.map((folder) => ({ id: folder.id, label: getFolderLabel(folder) })),
     [rootFolders],
-  );
-
-  const activePendingUploads = pendingUploads.filter(
-    (item) => item.folderId === activeFolderId,
   );
 
   const filteredChildFolders = useMemo(
@@ -429,6 +396,42 @@ export function FileManagerWorkspace({
     [activeFolderId, folderTree],
   );
 
+  const {
+    expandedFolderIds,
+    mobileExplorerCollapsed,
+    mobileSection,
+    navigateToFolder,
+    setMobileExplorerCollapsed,
+    setMobileSection,
+    toggleFolderExpanded,
+  } = useFileManagerNavigationState({
+    activeFolderId,
+    activeFolderTreePathIds,
+    setActiveFolderId,
+    setSelectedFolderId,
+  });
+
+  const {
+    enqueueUploadFiles,
+    pendingUploads,
+    queuedUploadsCount,
+  } = useFileUploadFlow({
+    accessToken,
+    devRole,
+    getActiveFolderId,
+    loadActiveFolder,
+    loadFolders,
+    onNavigateToFolder: navigateToFolder,
+    setError,
+    setInfo,
+  });
+
+  const uploadBusy = pendingUploads.length > 0 || queuedUploadsCount > 0;
+
+  const activePendingUploads = pendingUploads.filter(
+    (item) => item.folderId === activeFolderId,
+  );
+
   const activeFolderBreadcrumbLabel = activeFolder
     ? activeFolder.breadcrumb.map((folder) => getFolderLabel(folder)).join(" / ")
     : "";
@@ -472,23 +475,6 @@ export function FileManagerWorkspace({
     getFolderLabel(selectedFolder) || selectedFile?.fileName || "Nenhum item";
 
   useEffect(() => {
-    if (activeFolderTreePathIds.length === 0) return;
-
-    setExpandedFolderIds((current) => {
-      let changed = false;
-      const next = new Set(current);
-
-      for (const folderId of activeFolderTreePathIds) {
-        if (next.has(folderId)) continue;
-        next.add(folderId);
-        changed = true;
-      }
-
-      return changed ? next : current;
-    });
-  }, [activeFolderTreePathIds]);
-
-  useEffect(() => {
     if (!selectedFolderId) return;
     if (filteredChildFolders.some((folder) => folder.id === selectedFolderId)) return;
     setSelectedFolderId(null);
@@ -522,10 +508,6 @@ export function FileManagerWorkspace({
   useEffect(() => {
     void loadAutomationSettings();
   }, [loadAutomationSettings]);
-
-  useEffect(() => {
-    setMobileSection("browser");
-  }, [activeFolderId]);
 
   function openCreatePanel(parentFolderId: string | null) {
     openCreatePanelState(parentFolderId);
@@ -1074,15 +1056,6 @@ export function FileManagerWorkspace({
     }
   }
 
-  function navigateToFolder(folderId: string) {
-    setActiveFolderId(folderId);
-    setSelectedFolderId(null);
-
-    setMobileSection("browser");
-
-    setMobileExplorerCollapsed(true);
-  }
-
   function handleSelectFile(fileId: string) {
     setSelectedFolderId(null);
 
@@ -1226,20 +1199,6 @@ export function FileManagerWorkspace({
     if (event.dataTransfer.files.length > 0) {
       void handleUpload(event.dataTransfer.files, activeFolder.folder.id);
     }
-  }
-
-  function toggleFolderExpanded(folderId: string) {
-    setExpandedFolderIds((current) => {
-      const next = new Set(current);
-
-      if (next.has(folderId)) {
-        next.delete(folderId);
-      } else {
-        next.add(folderId);
-      }
-
-      return next;
-    });
   }
 
   function renderFolderTreeNode(folder: FolderTreeNode, depth = 0) {

--- a/components/files/file-manager-workspace.tsx
+++ b/components/files/file-manager-workspace.tsx
@@ -19,8 +19,6 @@ import {
   deleteFileFolder,
   deleteFolderFile,
   fetchFileAutomationSettings,
-  fetchFileFolderDetail,
-  fetchFileFolders,
   reconcileFileAutomations,
   renameFolderFile,
   reorderFolderFiles,
@@ -46,6 +44,7 @@ import {
   flattenFolderOptions,
   type FolderTreeNode,
 } from "@/components/files/folder-tree";
+import { useFileManagerFolderData } from "@/components/files/hooks/use-file-manager-folder-data";
 import { useFileManagerQueryState } from "@/components/files/hooks/use-file-manager-query-state";
 import { useFileSelection } from "@/components/files/hooks/use-file-selection";
 import { useFileUploadFlow } from "@/components/files/hooks/use-file-upload-flow";
@@ -216,30 +215,6 @@ export function FileManagerWorkspace({
 
   const uploadSectionRef = useRef<HTMLElement | null>(null);
 
-  const activeFolderIdRef = useRef<string | null>(null);
-
-  const restoredFolderIdRef = useRef<string | null>(null);
-
-  const loadFoldersRef = useRef<
-    (preferredFolderId?: string | null) => Promise<void>
-  >(async () => {});
-
-  const loadActiveFolderRef = useRef<(folderId: string) => Promise<void>>(
-    async () => {},
-  );
-
-  const [folders, setFolders] = useState<FileFolderSummary[]>([]);
-
-  const [activeFolderId, setActiveFolderId] = useState<string | null>(null);
-
-  const [activeFolder, setActiveFolder] = useState<FileFolderDetail | null>(
-    null,
-  );
-
-  const [foldersLoading, setFoldersLoading] = useState(true);
-
-  const [folderLoading, setFolderLoading] = useState(false);
-
   const [submitting, setSubmitting] = useState(false);
 
   const [downloadAllPending, setDownloadAllPending] = useState(false);
@@ -249,16 +224,32 @@ export function FileManagerWorkspace({
   const [info, setInfo] = useState<string | null>(null);
 
   const {
+    activeFolder,
+    activeFolderId,
+    folderLoading,
+    folders,
+    foldersLoading,
+    getActiveFolderId,
+    loadActiveFolder,
+    loadFolders,
+    setActiveFolder,
+    setActiveFolderId,
+  } = useFileManagerFolderData({
+    accessToken,
+    devRole,
+    setError,
+  });
+
+  const {
     enqueueUploadFiles,
     pendingUploads,
     queuedUploadsCount,
   } = useFileUploadFlow({
     accessToken,
     devRole,
-    getActiveFolderId: () => activeFolderIdRef.current,
-    loadActiveFolder: (folderId) => loadActiveFolderRef.current(folderId),
-    loadFolders: (preferredFolderId) =>
-      loadFoldersRef.current(preferredFolderId),
+    getActiveFolderId,
+    loadActiveFolder,
+    loadFolders,
     onNavigateToFolder: (folderId) => {
       navigateToFolder(folderId);
     },
@@ -495,10 +486,6 @@ export function FileManagerWorkspace({
   }, [activeFolderTreePathIds]);
 
   useEffect(() => {
-    activeFolderIdRef.current = activeFolderId;
-  }, [activeFolderId]);
-
-  useEffect(() => {
     if (!activeFolder) {
       setEditName("");
 
@@ -575,73 +562,6 @@ export function FileManagerWorkspace({
     };
   }, [selectedFile, selectedPreviewKind]);
 
-  const loadFolders = useCallback(
-    async (preferredFolderId?: string | null) => {
-      setFoldersLoading(true);
-
-      setError(null);
-
-      try {
-        const response = await fetchFileFolders({ accessToken, devRole });
-
-        const nextFolders = response.folders;
-
-        setFolders(nextFolders);
-
-        setActiveFolderId((current) => {
-          const preferred =
-            preferredFolderId ?? current ?? restoredFolderIdRef.current;
-
-          if (
-            preferred &&
-            nextFolders.some((folder) => folder.id === preferred)
-          ) {
-            return preferred;
-          }
-
-          return nextFolders[0]?.id ?? null;
-        });
-      } catch (nextError) {
-        setError(
-          nextError instanceof Error
-            ? nextError.message
-            : "Falha ao carregar pastas.",
-        );
-      } finally {
-        setFoldersLoading(false);
-      }
-    },
-    [accessToken, devRole],
-  );
-
-  const loadActiveFolder = useCallback(
-    async (folderId: string) => {
-      setFolderLoading(true);
-
-      setError(null);
-
-      try {
-        const detail = await fetchFileFolderDetail(folderId, {
-          accessToken,
-          devRole,
-        });
-
-        setActiveFolder(detail);
-      } catch (nextError) {
-        setActiveFolder(null);
-
-        setError(
-          nextError instanceof Error
-            ? nextError.message
-            : "Falha ao carregar a pasta selecionada.",
-        );
-      } finally {
-        setFolderLoading(false);
-      }
-    },
-    [accessToken, devRole],
-  );
-
   const loadAutomationSettings = useCallback(async () => {
     if (!canManage) return;
 
@@ -667,26 +587,9 @@ export function FileManagerWorkspace({
     }
   }, [accessToken, canManage, devRole]);
 
-  loadFoldersRef.current = loadFolders;
-  loadActiveFolderRef.current = loadActiveFolder;
-
-  useEffect(() => {
-    void loadFolders();
-  }, [loadFolders]);
-
   useEffect(() => {
     void loadAutomationSettings();
   }, [loadAutomationSettings]);
-
-  useEffect(() => {
-    if (!activeFolderId) {
-      setActiveFolder(null);
-
-      return;
-    }
-
-    void loadActiveFolder(activeFolderId);
-  }, [activeFolderId, loadActiveFolder]);
 
   useEffect(() => {
     setMobileSection("browser");

--- a/components/files/file-manager-workspace.tsx
+++ b/components/files/file-manager-workspace.tsx
@@ -45,6 +45,7 @@ import {
   type FolderTreeNode,
 } from "@/components/files/folder-tree";
 import { useFileManagerFolderData } from "@/components/files/hooks/use-file-manager-folder-data";
+import { useFileManagerFolderFormState } from "@/components/files/hooks/use-file-manager-folder-form-state";
 import { useFileManagerQueryState } from "@/components/files/hooks/use-file-manager-query-state";
 import { useFileSelection } from "@/components/files/hooks/use-file-selection";
 import { useFileUploadFlow } from "@/components/files/hooks/use-file-upload-flow";
@@ -69,10 +70,6 @@ type FileManagerWorkspaceProps = {
   devRole?: Role | null;
 
   onSignOut: () => void | Promise<void>;
-};
-
-type CreatePanelState = null | {
-  parentFolderId: string | null;
 };
 
 type ViewMode = "compact" | "medium" | "large";
@@ -257,10 +254,6 @@ export function FileManagerWorkspace({
     setInfo,
   });
 
-  const [createPanel, setCreatePanel] = useState<CreatePanelState>(null);
-
-  const [settingsOpen, setSettingsOpen] = useState(false);
-
   const [automationPanelOpen, setAutomationPanelOpen] = useState(false);
 
   const [automationSettings, setAutomationSettings] =
@@ -276,17 +269,25 @@ export function FileManagerWorkspace({
       EMPTY_AUTOMATION_REPOSITORIES,
     );
 
-  const [createName, setCreateName] = useState("");
-
-  const [createDescription, setCreateDescription] = useState("");
-
-  const [createParentFolderId, setCreateParentFolderId] = useState("");
-
-  const [editName, setEditName] = useState("");
-
-  const [editDescription, setEditDescription] = useState("");
-
-  const [editParentFolderId, setEditParentFolderId] = useState("");
+  const {
+    closeCreatePanel: resetCreatePanel,
+    createDescription,
+    createName,
+    createPanel,
+    createParentFolderId,
+    editDescription,
+    editName,
+    editParentFolderId,
+    openCreatePanel: openCreatePanelState,
+    setCreateDescription,
+    setCreateName,
+    setCreateParentFolderId,
+    setEditDescription,
+    setEditName,
+    setEditParentFolderId,
+    setSettingsOpen,
+    settingsOpen,
+  } = useFileManagerFolderFormState({ activeFolder });
 
   const {
     clearFileFilters,
@@ -486,28 +487,6 @@ export function FileManagerWorkspace({
   }, [activeFolderTreePathIds]);
 
   useEffect(() => {
-    if (!activeFolder) {
-      setEditName("");
-
-      setEditDescription("");
-
-      setEditParentFolderId("");
-
-      setSettingsOpen(false);
-
-      return;
-    }
-
-    setEditName(activeFolder.folder.name);
-
-    setEditDescription(activeFolder.folder.description ?? "");
-
-    setEditParentFolderId(activeFolder.folder.parentFolderId ?? "");
-
-    setSettingsOpen(false);
-  }, [activeFolder]);
-
-  useEffect(() => {
     if (!selectedFolderId) return;
     if (filteredChildFolders.some((folder) => folder.id === selectedFolderId)) return;
     setSelectedFolderId(null);
@@ -596,13 +575,7 @@ export function FileManagerWorkspace({
   }, [activeFolderId]);
 
   function openCreatePanel(parentFolderId: string | null) {
-    setCreatePanel({ parentFolderId });
-
-    setCreateName("");
-
-    setCreateDescription("");
-
-    setCreateParentFolderId(parentFolderId ?? "");
+    openCreatePanelState(parentFolderId);
 
     setMobileSection("manage");
 
@@ -612,13 +585,7 @@ export function FileManagerWorkspace({
   }
 
   function closeCreatePanel() {
-    setCreatePanel(null);
-
-    setCreateName("");
-
-    setCreateDescription("");
-
-    setCreateParentFolderId("");
+    resetCreatePanel();
   }
 
   async function handleCreateFolder(event: FormEvent<HTMLFormElement>) {

--- a/components/files/file-manager-workspace.tsx
+++ b/components/files/file-manager-workspace.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/components/files/folder-tree";
 import { useFileManagerFolderData } from "@/components/files/hooks/use-file-manager-folder-data";
 import { useFileManagerFolderFormState } from "@/components/files/hooks/use-file-manager-folder-form-state";
+import { useFileManagerPreviewText } from "@/components/files/hooks/use-file-manager-preview-text";
 import { useFileManagerQueryState } from "@/components/files/hooks/use-file-manager-query-state";
 import { useFileSelection } from "@/components/files/hooks/use-file-selection";
 import { useFileUploadFlow } from "@/components/files/hooks/use-file-upload-flow";
@@ -301,10 +302,6 @@ export function FileManagerWorkspace({
     setPreviewMode,
   } = useFileManagerQueryState();
 
-  const [previewText, setPreviewText] = useState<string>("");
-
-  const [previewLoading, setPreviewLoading] = useState(false);
-
   const [viewMode, setViewMode] = useState<ViewMode>("medium");
 
   const [renamingFileId, setRenamingFileId] = useState<string | null>(null);
@@ -419,6 +416,11 @@ export function FileManagerWorkspace({
     selectedFile?.fileName,
   );
 
+  const { previewLoading, previewText } = useFileManagerPreviewText({
+    selectedFile,
+    selectedPreviewKind,
+  });
+
   const activeRootFolderId =
     activeFolder?.breadcrumb[0]?.id ?? activeFolder?.folder.id ?? null;
 
@@ -491,55 +493,6 @@ export function FileManagerWorkspace({
     if (filteredChildFolders.some((folder) => folder.id === selectedFolderId)) return;
     setSelectedFolderId(null);
   }, [filteredChildFolders, selectedFolderId]);
-
-  useEffect(() => {
-    if (
-      !selectedFile ||
-      selectedPreviewKind !== "text" ||
-      !selectedFile.previewUrl
-    ) {
-      setPreviewText("");
-
-      setPreviewLoading(false);
-
-      return;
-    }
-
-    let active = true;
-
-    setPreviewLoading(true);
-
-    fetch(selectedFile.previewUrl)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error("Falha ao carregar preview de texto.");
-        }
-
-        return response.text();
-      })
-
-      .then((text) => {
-        if (!active) return;
-
-        setPreviewText(text.slice(0, 12000));
-      })
-
-      .catch(() => {
-        if (!active) return;
-
-        setPreviewText("Nao foi possivel gerar preview textual deste arquivo.");
-      })
-
-      .finally(() => {
-        if (!active) return;
-
-        setPreviewLoading(false);
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [selectedFile, selectedPreviewKind]);
 
   const loadAutomationSettings = useCallback(async () => {
     if (!canManage) return;

--- a/components/files/file-manager-workspace.tsx
+++ b/components/files/file-manager-workspace.tsx
@@ -18,7 +18,6 @@ import {
   createFileFolder,
   deleteFileFolder,
   deleteFolderFile,
-  fetchFileAutomationSettings,
   reconcileFileAutomations,
   renameFolderFile,
   reorderFolderFiles,
@@ -28,8 +27,6 @@ import {
 
 import type {
   FileAutomationRepositoryKey,
-  FileAutomationSettings,
-  FileFolderDetail,
   FileFolderSummary,
   FileItem,
   VehicleFolderDisplayField,
@@ -44,6 +41,7 @@ import {
   flattenFolderOptions,
   type FolderTreeNode,
 } from "@/components/files/folder-tree";
+import { useFileManagerAutomationSettings } from "@/components/files/hooks/use-file-manager-automation-settings";
 import { useFileManagerFolderData } from "@/components/files/hooks/use-file-manager-folder-data";
 import { useFileManagerFolderFormState } from "@/components/files/hooks/use-file-manager-folder-form-state";
 import { useFileManagerNavigationState } from "@/components/files/hooks/use-file-manager-navigation-state";
@@ -98,13 +96,6 @@ const VEHICLE_FOLDER_DISPLAY_OPTIONS: Array<{
   { value: "modelo", label: "Modelo" },
   { value: "id", label: "ID" },
 ];
-
-const EMPTY_AUTOMATION_REPOSITORIES: Record<FileAutomationRepositoryKey, string> = {
-  vehicle_photos_active: "",
-  vehicle_photos_sold: "",
-  vehicle_documents_active: "",
-  vehicle_documents_archive: "",
-};
 
 function formatDateTime(value: string) {
   return new Date(value).toLocaleString("pt-BR");
@@ -237,20 +228,22 @@ export function FileManagerWorkspace({
     setError,
   });
 
-  const [automationPanelOpen, setAutomationPanelOpen] = useState(false);
-
-  const [automationSettings, setAutomationSettings] =
-    useState<FileAutomationSettings | null>(null);
-
-  const [automationLoading, setAutomationLoading] = useState(false);
-
-  const [automationDisplayField, setAutomationDisplayField] =
-    useState<VehicleFolderDisplayField>("placa");
-
-  const [automationRepositories, setAutomationRepositories] =
-    useState<Record<FileAutomationRepositoryKey, string>>(
-      EMPTY_AUTOMATION_REPOSITORIES,
-    );
+  const {
+    applyAutomationSettings,
+    automationDisplayField,
+    automationLoading,
+    automationPanelOpen,
+    automationRepositories,
+    automationSettings,
+    setAutomationDisplayField,
+    setAutomationPanelOpen,
+    setAutomationRepositories,
+  } = useFileManagerAutomationSettings({
+    accessToken,
+    canManage,
+    devRole,
+    setError,
+  });
 
   const {
     closeCreatePanel: resetCreatePanel,
@@ -479,35 +472,6 @@ export function FileManagerWorkspace({
     if (filteredChildFolders.some((folder) => folder.id === selectedFolderId)) return;
     setSelectedFolderId(null);
   }, [filteredChildFolders, selectedFolderId]);
-
-  const loadAutomationSettings = useCallback(async () => {
-    if (!canManage) return;
-
-    setAutomationLoading(true);
-
-    try {
-      const settings = await fetchFileAutomationSettings({
-        accessToken,
-        devRole,
-      });
-
-      setAutomationSettings(settings);
-      setAutomationDisplayField(settings.displayField);
-      setAutomationRepositories(settings.repositories);
-    } catch (nextError) {
-      setError(
-        nextError instanceof Error
-          ? nextError.message
-          : "Falha ao carregar automacoes.",
-      );
-    } finally {
-      setAutomationLoading(false);
-    }
-  }, [accessToken, canManage, devRole]);
-
-  useEffect(() => {
-    void loadAutomationSettings();
-  }, [loadAutomationSettings]);
 
   function openCreatePanel(parentFolderId: string | null) {
     openCreatePanelState(parentFolderId);
@@ -1112,9 +1076,7 @@ export function FileManagerWorkspace({
         { accessToken, devRole },
       );
 
-      setAutomationSettings(settings);
-      setAutomationDisplayField(settings.displayField);
-      setAutomationRepositories(settings.repositories);
+      applyAutomationSettings(settings);
       await loadFolders(activeFolderId);
       if (activeFolderId) {
         await loadActiveFolder(activeFolderId);

--- a/components/files/hooks/use-file-manager-automation-settings.ts
+++ b/components/files/hooks/use-file-manager-automation-settings.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { fetchFileAutomationSettings } from "@/components/files/api";
+import type {
+  FileAutomationRepositoryKey,
+  FileAutomationSettings,
+  VehicleFolderDisplayField,
+} from "@/components/files/types";
+import type { Role } from "@/components/ui-grid/types";
+
+const EMPTY_AUTOMATION_REPOSITORIES: Record<FileAutomationRepositoryKey, string> = {
+  vehicle_photos_active: "",
+  vehicle_photos_sold: "",
+  vehicle_documents_active: "",
+  vehicle_documents_archive: "",
+};
+
+type UseFileManagerAutomationSettingsParams = {
+  accessToken: string | null;
+  canManage: boolean;
+  devRole?: Role | null;
+  setError: (message: string | null) => void;
+};
+
+export function useFileManagerAutomationSettings({
+  accessToken,
+  canManage,
+  devRole,
+  setError,
+}: UseFileManagerAutomationSettingsParams) {
+  const [automationPanelOpen, setAutomationPanelOpen] = useState(false);
+  const [automationSettings, setAutomationSettings] =
+    useState<FileAutomationSettings | null>(null);
+  const [automationLoading, setAutomationLoading] = useState(false);
+  const [automationDisplayField, setAutomationDisplayField] =
+    useState<VehicleFolderDisplayField>("placa");
+  const [automationRepositories, setAutomationRepositories] =
+    useState<Record<FileAutomationRepositoryKey, string>>(
+      EMPTY_AUTOMATION_REPOSITORIES,
+    );
+
+  const applyAutomationSettings = useCallback(
+    (settings: FileAutomationSettings) => {
+      setAutomationSettings(settings);
+      setAutomationDisplayField(settings.displayField);
+      setAutomationRepositories(settings.repositories);
+    },
+    [],
+  );
+
+  const loadAutomationSettings = useCallback(async () => {
+    if (!canManage) return;
+
+    setAutomationLoading(true);
+
+    try {
+      const settings = await fetchFileAutomationSettings({
+        accessToken,
+        devRole,
+      });
+
+      applyAutomationSettings(settings);
+    } catch (nextError) {
+      setError(
+        nextError instanceof Error
+          ? nextError.message
+          : "Falha ao carregar automacoes.",
+      );
+    } finally {
+      setAutomationLoading(false);
+    }
+  }, [accessToken, applyAutomationSettings, canManage, devRole, setError]);
+
+  useEffect(() => {
+    void loadAutomationSettings();
+  }, [loadAutomationSettings]);
+
+  return {
+    applyAutomationSettings,
+    automationDisplayField,
+    automationLoading,
+    automationPanelOpen,
+    automationRepositories,
+    automationSettings,
+    setAutomationDisplayField,
+    setAutomationPanelOpen,
+    setAutomationRepositories,
+  };
+}

--- a/components/files/hooks/use-file-manager-folder-data.ts
+++ b/components/files/hooks/use-file-manager-folder-data.ts
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  fetchFileFolderDetail,
+  fetchFileFolders,
+} from "@/components/files/api";
+import type {
+  FileFolderDetail,
+  FileFolderSummary,
+} from "@/components/files/types";
+import type { Role } from "@/components/ui-grid/types";
+
+type UseFileManagerFolderDataParams = {
+  accessToken: string | null;
+  devRole?: Role | null;
+  setError: (message: string | null) => void;
+};
+
+export function useFileManagerFolderData({
+  accessToken,
+  devRole,
+  setError,
+}: UseFileManagerFolderDataParams) {
+  const activeFolderIdRef = useRef<string | null>(null);
+  const restoredFolderIdRef = useRef<string | null>(null);
+
+  const [folders, setFolders] = useState<FileFolderSummary[]>([]);
+  const [activeFolderId, setActiveFolderId] = useState<string | null>(null);
+  const [activeFolder, setActiveFolder] = useState<FileFolderDetail | null>(
+    null,
+  );
+  const [foldersLoading, setFoldersLoading] = useState(true);
+  const [folderLoading, setFolderLoading] = useState(false);
+
+  useEffect(() => {
+    activeFolderIdRef.current = activeFolderId;
+  }, [activeFolderId]);
+
+  const loadFolders = useCallback(
+    async (preferredFolderId?: string | null) => {
+      setFoldersLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetchFileFolders({ accessToken, devRole });
+        const nextFolders = response.folders;
+
+        setFolders(nextFolders);
+        setActiveFolderId((current) => {
+          const preferred =
+            preferredFolderId ?? current ?? restoredFolderIdRef.current;
+
+          if (
+            preferred &&
+            nextFolders.some((folder) => folder.id === preferred)
+          ) {
+            return preferred;
+          }
+
+          return nextFolders[0]?.id ?? null;
+        });
+      } catch (nextError) {
+        setError(
+          nextError instanceof Error
+            ? nextError.message
+            : "Falha ao carregar pastas.",
+        );
+      } finally {
+        setFoldersLoading(false);
+      }
+    },
+    [accessToken, devRole, setError],
+  );
+
+  const loadActiveFolder = useCallback(
+    async (folderId: string) => {
+      setFolderLoading(true);
+      setError(null);
+
+      try {
+        const detail = await fetchFileFolderDetail(folderId, {
+          accessToken,
+          devRole,
+        });
+
+        setActiveFolder(detail);
+      } catch (nextError) {
+        setActiveFolder(null);
+        setError(
+          nextError instanceof Error
+            ? nextError.message
+            : "Falha ao carregar a pasta selecionada.",
+        );
+      } finally {
+        setFolderLoading(false);
+      }
+    },
+    [accessToken, devRole, setError],
+  );
+
+  useEffect(() => {
+    void loadFolders();
+  }, [loadFolders]);
+
+  useEffect(() => {
+    if (!activeFolderId) {
+      setActiveFolder(null);
+      return;
+    }
+
+    void loadActiveFolder(activeFolderId);
+  }, [activeFolderId, loadActiveFolder]);
+
+  const getActiveFolderId = useCallback(() => activeFolderIdRef.current, []);
+
+  return {
+    activeFolder,
+    activeFolderId,
+    folderLoading,
+    folders,
+    foldersLoading,
+    getActiveFolderId,
+    loadActiveFolder,
+    loadFolders,
+    setActiveFolder,
+    setActiveFolderId,
+  };
+}

--- a/components/files/hooks/use-file-manager-folder-form-state.ts
+++ b/components/files/hooks/use-file-manager-folder-form-state.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+
+import type { FileFolderDetail } from "@/components/files/types";
+
+export type CreatePanelState = null | {
+  parentFolderId: string | null;
+};
+
+type UseFileManagerFolderFormStateParams = {
+  activeFolder: FileFolderDetail | null;
+};
+
+export function useFileManagerFolderFormState({
+  activeFolder,
+}: UseFileManagerFolderFormStateParams) {
+  const [createPanel, setCreatePanel] = useState<CreatePanelState>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [createName, setCreateName] = useState("");
+  const [createDescription, setCreateDescription] = useState("");
+  const [createParentFolderId, setCreateParentFolderId] = useState("");
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editParentFolderId, setEditParentFolderId] = useState("");
+
+  useEffect(() => {
+    if (!activeFolder) {
+      setEditName("");
+      setEditDescription("");
+      setEditParentFolderId("");
+      setSettingsOpen(false);
+      return;
+    }
+
+    setEditName(activeFolder.folder.name);
+    setEditDescription(activeFolder.folder.description ?? "");
+    setEditParentFolderId(activeFolder.folder.parentFolderId ?? "");
+    setSettingsOpen(false);
+  }, [activeFolder]);
+
+  function openCreatePanel(parentFolderId: string | null) {
+    setCreatePanel({ parentFolderId });
+    setCreateName("");
+    setCreateDescription("");
+    setCreateParentFolderId(parentFolderId ?? "");
+  }
+
+  function closeCreatePanel() {
+    setCreatePanel(null);
+    setCreateName("");
+    setCreateDescription("");
+    setCreateParentFolderId("");
+  }
+
+  return {
+    closeCreatePanel,
+    createDescription,
+    createName,
+    createPanel,
+    createParentFolderId,
+    editDescription,
+    editName,
+    editParentFolderId,
+    openCreatePanel,
+    setCreateDescription,
+    setCreateName,
+    setCreateParentFolderId,
+    setEditDescription,
+    setEditName,
+    setEditParentFolderId,
+    setSettingsOpen,
+    settingsOpen,
+  };
+}

--- a/components/files/hooks/use-file-manager-navigation-state.ts
+++ b/components/files/hooks/use-file-manager-navigation-state.ts
@@ -1,0 +1,85 @@
+import {
+  useCallback,
+  useEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
+
+export type MobileFilesSection = "browser" | "preview" | "manage";
+
+type UseFileManagerNavigationStateParams = {
+  activeFolderId: string | null;
+  activeFolderTreePathIds: string[];
+  setActiveFolderId: Dispatch<SetStateAction<string | null>>;
+  setSelectedFolderId: Dispatch<SetStateAction<string | null>>;
+};
+
+export function useFileManagerNavigationState({
+  activeFolderId,
+  activeFolderTreePathIds,
+  setActiveFolderId,
+  setSelectedFolderId,
+}: UseFileManagerNavigationStateParams) {
+  const [mobileSection, setMobileSection] =
+    useState<MobileFilesSection>("browser");
+  const [mobileExplorerCollapsed, setMobileExplorerCollapsed] = useState(true);
+  const [expandedFolderIds, setExpandedFolderIds] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  useEffect(() => {
+    if (activeFolderTreePathIds.length === 0) return;
+
+    setExpandedFolderIds((current) => {
+      let changed = false;
+      const next = new Set(current);
+
+      for (const folderId of activeFolderTreePathIds) {
+        if (next.has(folderId)) continue;
+        next.add(folderId);
+        changed = true;
+      }
+
+      return changed ? next : current;
+    });
+  }, [activeFolderTreePathIds]);
+
+  useEffect(() => {
+    setMobileSection("browser");
+  }, [activeFolderId]);
+
+  const navigateToFolder = useCallback(
+    (folderId: string) => {
+      setActiveFolderId(folderId);
+      setSelectedFolderId(null);
+      setMobileSection("browser");
+      setMobileExplorerCollapsed(true);
+    },
+    [setActiveFolderId, setSelectedFolderId],
+  );
+
+  const toggleFolderExpanded = useCallback((folderId: string) => {
+    setExpandedFolderIds((current) => {
+      const next = new Set(current);
+
+      if (next.has(folderId)) {
+        next.delete(folderId);
+      } else {
+        next.add(folderId);
+      }
+
+      return next;
+    });
+  }, []);
+
+  return {
+    expandedFolderIds,
+    mobileExplorerCollapsed,
+    mobileSection,
+    navigateToFolder,
+    setMobileExplorerCollapsed,
+    setMobileSection,
+    toggleFolderExpanded,
+  };
+}

--- a/components/files/hooks/use-file-manager-preview-text.ts
+++ b/components/files/hooks/use-file-manager-preview-text.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+
+import type { FileItem } from "@/components/files/types";
+import type { FilePreviewKind } from "@/lib/files/shared";
+
+type UseFileManagerPreviewTextParams = {
+  selectedFile: Pick<FileItem, "previewUrl"> | null;
+  selectedPreviewKind: FilePreviewKind;
+};
+
+export function useFileManagerPreviewText({
+  selectedFile,
+  selectedPreviewKind,
+}: UseFileManagerPreviewTextParams) {
+  const [previewText, setPreviewText] = useState<string>("");
+  const [previewLoading, setPreviewLoading] = useState(false);
+
+  useEffect(() => {
+    if (
+      !selectedFile ||
+      selectedPreviewKind !== "text" ||
+      !selectedFile.previewUrl
+    ) {
+      setPreviewText("");
+      setPreviewLoading(false);
+      return;
+    }
+
+    let active = true;
+
+    setPreviewLoading(true);
+
+    fetch(selectedFile.previewUrl)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Falha ao carregar preview de texto.");
+        }
+
+        return response.text();
+      })
+      .then((text) => {
+        if (!active) return;
+
+        setPreviewText(text.slice(0, 12000));
+      })
+      .catch(() => {
+        if (!active) return;
+
+        setPreviewText("Nao foi possivel gerar preview textual deste arquivo.");
+      })
+      .finally(() => {
+        if (!active) return;
+
+        setPreviewLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [selectedFile, selectedPreviewKind]);
+
+  return {
+    previewLoading,
+    previewText,
+  };
+}


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 2 (Wave 2)
- Escopo tocado: `components/files/file-manager-workspace.tsx`, `components/files/hooks/`

## Resumo
**Wave 2 — quebra de monólito.** Continuação do padrão estabelecido na Wave 1 (4 hooks extraídos de `holistic-sheet.tsx`). Trabalho conduzido por **Codex gpt-5.5 xhigh** em worktree isolado.

5 hooks novos em `components/files/hooks/`:

| Commit | Hook | Responsabilidade |
|---|---|---|
| `fb92aa1` | `folder data hook` | dados/estado de pastas |
| `56a62e8` | `folder form state hook` | formulário de pasta |
| `dd3c58e` | `preview text hook` | preview de texto (fetch + slice 12k) |
| `54d3851` | `navigation state hook` | estado de navegação |
| `5d79146` | `automation settings hook` | configurações de automação |

## Metas mínimas de qualidade
### Linhas antes/depois
- `file-manager-workspace.tsx`: **3.101 → 2.845** (-256 linhas locais; ganho é modularidade)
- Novos hooks: +5 arquivos em `components/files/hooks/`

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0
- `npx tsc --noEmit`: exit 0 após cada extração
- `any` introduzidos: 0

### Evidência de testes
- [x] Testes unitários: **passaram após cada um dos 5 commits**
- [x] `npm run build`: passou (exit 0)
- [x] E2E: `tests/e2e/files.spec.ts` não tocado — deve validar comportamento na review
- Comandos:
  ```txt
  npm run test:unit  → ✅ após cada commit
  npx tsc --noEmit   → exit 0
  npm run build      → exit 0
  ```

### Tempo de review
- Tempo total estimado: 30 min (5 commits sequenciais, hooks isolados)
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 2
- [x] Segurança validada (sem mudança de auth/policy)
- [x] Regressão visual validada (API pública do componente preservada)
- [x] Performance validada (hooks não introduzem re-render extra)

## Observações finais
- **`components/files/api.ts` não foi tocado** (consolidado na Wave 1 PR #30 — qualquer mexida quebraria `lib/api/http-client.ts`).
- **`tests/e2e/files.spec.ts` não foi tocado** — testes E2E preservados.
- **Parada deliberada** em filtros, seleção bulk e drawers — cruzam refs/layout/mutações. Wave 3.
- Riscos residuais:
  - Granularidade de re-renders: hooks expõem setters; revisar consumer.
  - Warnings pre-existentes em `components/ui-grid/api.ts` e `components/ui-grid/holistic-sheet.tsx` permanecem (fora do escopo).
- Plano de rollback: `git revert 5d79146 54d3851 dd3c58e 56a62e8 fb92aa1`

Commits: `fb92aa1` → `56a62e8` → `dd3c58e` → `54d3851` → `5d79146`
