### PR TITLE
refactor(ui-grid): wave 2 hook extraction from holistic-sheet

### DIFF
--- a/components/ui-grid/holistic-sheet.tsx
+++ b/components/ui-grid/holistic-sheet.tsx
@@ -101,6 +101,7 @@ import { useGridPriceContextDialogs } from "@/components/ui-grid/hooks/useGridPr
 import { useGridAnuncioInsights } from "@/components/ui-grid/hooks/useGridAnuncioInsights";
 import { useGridScrollSync } from "@/components/ui-grid/hooks/useGridScrollSync";
 import { cellKey, parseCellKey, useGridKeyboardSelection } from "@/components/ui-grid/hooks/useGridKeyboardSelection";
+import { useGridDrawerState } from "@/components/ui-grid/hooks/useGridDrawerState";
 import {
   normalizeWorkspacePanels,
   persistPaginationState,
@@ -368,16 +369,19 @@ export function HolisticSheet({
   const printFilterPopoverRef = useRef<HTMLDivElement>(null);
   const printFilterTriggerRefs = useRef<Record<string, HTMLButtonElement | null>>({});
   const [relationCache, setRelationCache] = useState<Partial<Record<SheetKey, GridListPayload>>>({});
-  const [relationDialog, setRelationDialog] = useState<{
-    sourceColumn: string;
-    targetTable: SheetKey;
-    keyColumn: string;
-    target: RelationDialogTarget;
-  } | null>(null);
-  const [relationDialogLoading, setRelationDialogLoading] = useState(false);
-  const [hiddenColumnsDialogOpen, setHiddenColumnsDialogOpen] = useState(false);
-  const [selectionDialogOpen, setSelectionDialogOpen] = useState(false);
-  const [activeFiltersDialogOpen, setActiveFiltersDialogOpen] = useState(false);
+  const {
+    activeFiltersDialogOpen,
+    closeGridDrawers,
+    hiddenColumnsDialogOpen,
+    relationDialog,
+    relationDialogLoading,
+    selectionDialogOpen,
+    setActiveFiltersDialogOpen,
+    setHiddenColumnsDialogOpen,
+    setRelationDialog,
+    setRelationDialogLoading,
+    setSelectionDialogOpen
+  } = useGridDrawerState();
   // TEMP(domínio: ações de impressão)
   const {
     printDialogOpen,
@@ -1672,7 +1676,7 @@ export function HolisticSheet({
         setRelationDialogLoading(false);
       }
     },
-    [relationCache, requestAuth]
+    [relationCache, requestAuth, setRelationDialogLoading]
   );
 
   const refreshRelationTable = useCallback(
@@ -1695,7 +1699,7 @@ export function HolisticSheet({
         setRelationDialogLoading(false);
       }
     },
-    [requestAuth]
+    [requestAuth, setRelationDialogLoading]
   );
 
   function openRelationDialogForColumn(column: string, target: RelationDialogTarget = "grid") {
@@ -3989,7 +3993,7 @@ export function HolisticSheet({
     if (isPrintTableScope) return;
     closePrintFilterPopover();
     setRelationDialog((prev) => (prev?.target === "print" ? null : prev));
-  }, [closePrintFilterPopover, isPrintTableScope]);
+  }, [closePrintFilterPopover, isPrintTableScope, setRelationDialog]);
 
   useEffect(() => {
     if (!filterPopoverColumn) return;
@@ -4109,10 +4113,7 @@ export function HolisticSheet({
     setLoadingRepeatedGroupIds(new Set());
     closeFilterPopover();
     closePrintFilterPopover();
-    setRelationDialog(null);
-    setHiddenColumnsDialogOpen(false);
-    setSelectionDialogOpen(false);
-    setActiveFiltersDialogOpen(false);
+    closeGridDrawers();
     setMassUpdateDialogOpen(false);
     setMassUpdateError(null);
     setPrintDialogOpen(false);
@@ -4137,6 +4138,7 @@ export function HolisticSheet({
   }, [
     activeSheetKey,
     clearSelection,
+    closeGridDrawers,
     closeFilterPopover,
     closePrintFilterPopover,
     prepareGridScrollRestore,

--- a/components/ui-grid/holistic-sheet.tsx
+++ b/components/ui-grid/holistic-sheet.tsx
@@ -99,11 +99,9 @@ import { useGridNavigationLayout } from "@/components/ui-grid/hooks/useGridNavig
 import { readCarFormSectionsStorage, useGridCarFormState } from "@/components/ui-grid/hooks/useGridCarFormState";
 import { useGridPriceContextDialogs } from "@/components/ui-grid/hooks/useGridPriceContextDialogs";
 import { useGridAnuncioInsights } from "@/components/ui-grid/hooks/useGridAnuncioInsights";
+import { useGridScrollSync } from "@/components/ui-grid/hooks/useGridScrollSync";
 import {
-  clampGridScrollToNode,
-  normalizeStoredGridScroll,
   normalizeWorkspacePanels,
-  persistGridScrollState,
   persistPaginationState,
   persistSelectionModes,
   persistSheetState,
@@ -373,10 +371,6 @@ export function HolisticSheet({
 
   const [queueDepth, setQueueDepth] = useState(0);
   const queueRef = useRef<Promise<void>>(Promise.resolve());
-  const gridRef = useRef<HTMLDivElement>(null);
-  const gridScrollRestoreRef = useRef<StoredGridScroll>({ left: 0, top: 0 });
-  const gridScrollRestoringRef = useRef(false);
-  const gridScrollWriteFrameRef = useRef<number | null>(null);
   const lastCellAnchorRef = useRef<CellAnchor | null>(null);
   const currentCellRef = useRef<CellAnchor | null>(null);
   const plateFieldRef = useRef<HTMLInputElement | null>(null);
@@ -1365,6 +1359,13 @@ export function HolisticSheet({
   const tablePixelWidth = useMemo(() => {
     return 48 + (isConferenceMode ? 92 : 0) + columns.reduce((sum, column) => sum + (resolvedColumnWidths[column] ?? 180), 0);
   }, [columns, isConferenceMode, resolvedColumnWidths]);
+  const { gridRef, handleGridScroll, prepareGridScrollRestore } = useGridScrollSync({
+    activeSheetKey,
+    isActiveSheetStateHydrated,
+    rowCount: viewRows.length,
+    showGridPanel,
+    tablePixelWidth
+  });
 
   function parseFilterSelection(expressionRaw: string): string[] {
     const expression = expressionRaw.trim();
@@ -2130,30 +2131,6 @@ export function HolisticSheet({
     setLastRowAnchor(null);
     setSelectCycleMode("default");
   }, [setCellAnchor, setCurrentCellAnchor, setLastRowAnchor, setSelectCycleMode, setSelectedCells, setSelectedRows]);
-
-  const handleGridScroll = useCallback(
-    (event: React.UIEvent<HTMLDivElement>) => {
-      if (!isActiveSheetStateHydrated) return;
-      if (gridScrollRestoringRef.current) return;
-
-      const next = normalizeStoredGridScroll({
-        left: event.currentTarget.scrollLeft,
-        top: event.currentTarget.scrollTop
-      });
-
-      gridScrollRestoreRef.current = next;
-
-      if (gridScrollWriteFrameRef.current != null) {
-        window.cancelAnimationFrame(gridScrollWriteFrameRef.current);
-      }
-
-      gridScrollWriteFrameRef.current = window.requestAnimationFrame(() => {
-        persistGridScrollState(activeSheetKey, next);
-        gridScrollWriteFrameRef.current = null;
-      });
-    },
-    [activeSheetKey, isActiveSheetStateHydrated]
-  );
 
   function moveOrderedValue(values: string[], value: string, direction: "up" | "down") {
     const index = values.indexOf(value);
@@ -4311,8 +4288,7 @@ export function HolisticSheet({
 
     setPage(Math.max(1, storedPagination.page || 1));
     setPageSize([25, 50, 100].includes(storedPagination.pageSize) ? storedPagination.pageSize : 25);
-    gridScrollRestoreRef.current = normalizeStoredGridScroll(storedScroll);
-    gridScrollRestoringRef.current = true;
+    prepareGridScrollRestore(storedScroll);
     setExpandedGroupIds(new Set());
     setRepetidosByGroup({});
     setLoadingRepeatedGroupIds(new Set());
@@ -4348,6 +4324,7 @@ export function HolisticSheet({
     clearSelection,
     closeFilterPopover,
     closePrintFilterPopover,
+    prepareGridScrollRestore,
     setDisplayColumnBySheet,
     setFilters,
     setMassUpdateDialogOpen,
@@ -4547,56 +4524,6 @@ export function HolisticSheet({
     if (!isActiveSheetStateHydrated) return;
     persistSelectionModes(activeSheetKey, selectionModes);
   }, [activeSheetKey, isActiveSheetStateHydrated, selectionModes]);
-
-  useEffect(() => {
-    return () => {
-      if (gridScrollWriteFrameRef.current != null) {
-        window.cancelAnimationFrame(gridScrollWriteFrameRef.current);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!showGridPanel || !isActiveSheetStateHydrated) return;
-
-    const node = gridRef.current;
-    if (!node) return;
-
-    const desiredScroll = normalizeStoredGridScroll(gridScrollRestoreRef.current);
-    let frame = 0;
-    let attempts = 0;
-
-    const restoreScroll = () => {
-      attempts += 1;
-      const clampedScroll = clampGridScrollToNode(node, desiredScroll);
-      const nextLeft = clampedScroll.left;
-      const nextTop = clampedScroll.top;
-
-      if (Math.abs(node.scrollLeft - nextLeft) > 1) {
-        node.scrollLeft = nextLeft;
-      }
-
-      if (Math.abs(node.scrollTop - nextTop) > 1) {
-        node.scrollTop = nextTop;
-      }
-
-      const needsRetry =
-        attempts < 60 && (Math.abs(node.scrollLeft - desiredScroll.left) > 1 || Math.abs(node.scrollTop - desiredScroll.top) > 1);
-
-      if (needsRetry) {
-        frame = window.requestAnimationFrame(restoreScroll);
-        return;
-      }
-
-      gridScrollRestoringRef.current = false;
-    };
-
-    frame = window.requestAnimationFrame(restoreScroll);
-
-    return () => {
-      window.cancelAnimationFrame(frame);
-    };
-  }, [activeSheetKey, isActiveSheetStateHydrated, showGridPanel, tablePixelWidth, viewRows.length]);
 
   useEffect(() => {
     if (!showFormPanel || showGridPanel || formMode !== "insert" || activeSheet.key !== "carros" || formBooting) return;

--- a/components/ui-grid/holistic-sheet.tsx
+++ b/components/ui-grid/holistic-sheet.tsx
@@ -93,13 +93,14 @@ import { installMojibakeSanitizer } from "@/lib/ux/mojibake";
 import { useGridDataSource } from "@/components/ui-grid/hooks/useGridDataSource";
 import { useGridMutations } from "@/components/ui-grid/hooks/useGridMutations";
 import { useGridFiltersAndSort } from "@/components/ui-grid/hooks/useGridFiltersAndSort";
-import { useGridSelection, type CellAnchor } from "@/components/ui-grid/hooks/useGridSelection";
+import { useGridSelection } from "@/components/ui-grid/hooks/useGridSelection";
 import { useGridPrintExport } from "@/components/ui-grid/hooks/useGridPrintExport";
 import { useGridNavigationLayout } from "@/components/ui-grid/hooks/useGridNavigationLayout";
 import { readCarFormSectionsStorage, useGridCarFormState } from "@/components/ui-grid/hooks/useGridCarFormState";
 import { useGridPriceContextDialogs } from "@/components/ui-grid/hooks/useGridPriceContextDialogs";
 import { useGridAnuncioInsights } from "@/components/ui-grid/hooks/useGridAnuncioInsights";
 import { useGridScrollSync } from "@/components/ui-grid/hooks/useGridScrollSync";
+import { cellKey, parseCellKey, useGridKeyboardSelection } from "@/components/ui-grid/hooks/useGridKeyboardSelection";
 import {
   normalizeWorkspacePanels,
   persistPaginationState,
@@ -244,15 +245,6 @@ function joinCompactLabels(...parts: Array<string | null | undefined>) {
     .join(" • ");
 }
 
-function cellKey(rIdx: number, cIdx: number) {
-  return `${rIdx}::${cIdx}`;
-}
-
-function parseCellKey(value: string): CellAnchor {
-  const [r, c] = value.split("::");
-  return { rIdx: Number(r), cIdx: Number(c) };
-}
-
 function createLocalId(prefix: string) {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return `${prefix}-${crypto.randomUUID()}`;
@@ -333,24 +325,17 @@ export function HolisticSheet({
     useGridNavigationLayout();
 
   // TEMP(domínio: seleção)
+  const gridSelection = useGridSelection();
   const {
     selectionModes,
     setSelectionModes,
     selectedRows,
     setSelectedRows,
     selectedCells,
-    setSelectedCells,
     lastClickedRowId,
-    setLastClickedRowId,
-    lastCellAnchor,
-    setLastCellAnchor,
-    currentCell,
-    setCurrentCell,
-    lastRowAnchor,
-    setLastRowAnchor,
     selectCycleMode,
     setSelectCycleMode
-  } = useGridSelection();
+  } = gridSelection;
 
   const [hiddenRowsByTable, setHiddenRowsByTable] = useState<Record<string, string[]>>({});
   const [conferenceRowsByTable, setConferenceRowsByTable] = useState<Partial<Record<SheetKey, string[]>>>({});
@@ -371,8 +356,6 @@ export function HolisticSheet({
 
   const [queueDepth, setQueueDepth] = useState(0);
   const queueRef = useRef<Promise<void>>(Promise.resolve());
-  const lastCellAnchorRef = useRef<CellAnchor | null>(null);
-  const currentCellRef = useRef<CellAnchor | null>(null);
   const plateFieldRef = useRef<HTMLInputElement | null>(null);
   const filterPopoverRef = useRef<HTMLDivElement>(null);
   const filterTriggerRefs = useRef<Record<string, HTMLButtonElement | null>>({});
@@ -1366,6 +1349,29 @@ export function HolisticSheet({
     showGridPanel,
     tablePixelWidth
   });
+  const {
+    clearSelectedRows,
+    clearSelection,
+    getCellSelectionAnchor,
+    handleCellClick,
+    handleRowToggle,
+    handleSelectAllCycle,
+    invertVisibleSelection,
+    moveCellSelectionBy,
+    selectVisibleRows
+  } = useGridKeyboardSelection({
+    activeSheetKey,
+    activeSheetPrimaryKey: activeSheet.primaryKey,
+    columns,
+    getSelectableRowIds,
+    gridRef,
+    isConferenceMode,
+    isEditorMode,
+    onOpenUpdateForm: openUpdateForm,
+    selection: gridSelection,
+    toggleConferenceRow,
+    viewRows
+  });
 
   function parseFilterSelection(expressionRaw: string): string[] {
     const expression = expressionRaw.trim();
@@ -2113,25 +2119,6 @@ export function HolisticSheet({
     setFilterPopoverPosition(resolvePopoverViewportPosition(rect));
   }, []);
 
-  const setCellAnchor = useCallback((next: CellAnchor | null) => {
-    lastCellAnchorRef.current = next;
-    setLastCellAnchor(next);
-  }, [setLastCellAnchor]);
-
-  const setCurrentCellAnchor = useCallback((next: CellAnchor | null) => {
-    currentCellRef.current = next;
-    setCurrentCell(next);
-  }, [setCurrentCell]);
-
-  const clearSelection = useCallback(() => {
-    setSelectedRows(new Set());
-    setSelectedCells(new Set());
-    setCellAnchor(null);
-    setCurrentCellAnchor(null);
-    setLastRowAnchor(null);
-    setSelectCycleMode("default");
-  }, [setCellAnchor, setCurrentCellAnchor, setLastRowAnchor, setSelectCycleMode, setSelectedCells, setSelectedRows]);
-
   function moveOrderedValue(values: string[], value: string, direction: "up" | "down") {
     const index = values.indexOf(value);
     if (index === -1) return values;
@@ -2424,138 +2411,6 @@ export function HolisticSheet({
     setEditingCell(null);
   }
 
-  function handleCellClick(rIdx: number, cIdx: number, event: React.MouseEvent) {
-    focusWithoutScroll(gridRef.current);
-    const row = viewRows[rIdx];
-    const rowId = String(row?.[activeSheet.primaryKey] ?? "");
-    if (rowId) setLastClickedRowId(rowId);
-
-    if (row && isEditorMode) {
-      void openUpdateForm(row);
-      return;
-    }
-
-    if (row && isConferenceMode) {
-      toggleConferenceRow(rowId);
-      return;
-    }
-
-    const key = cellKey(rIdx, cIdx);
-    setCurrentCellAnchor({ rIdx, cIdx });
-
-    if (event.shiftKey && lastCellAnchor) {
-      const next = new Set<string>();
-      const rMin = Math.min(lastCellAnchor.rIdx, rIdx);
-      const rMax = Math.max(lastCellAnchor.rIdx, rIdx);
-      const cMin = Math.min(lastCellAnchor.cIdx, cIdx);
-      const cMax = Math.max(lastCellAnchor.cIdx, cIdx);
-
-      for (let r = rMin; r <= rMax; r += 1) {
-        for (let c = cMin; c <= cMax; c += 1) {
-          next.add(cellKey(r, c));
-        }
-      }
-
-      setSelectedCells(next);
-      return;
-    }
-
-    if (event.metaKey || event.ctrlKey) {
-      setSelectedCells((prev) => {
-        const next = new Set(prev);
-        if (next.has(key)) next.delete(key);
-        else next.add(key);
-        return next;
-      });
-      setCellAnchor({ rIdx, cIdx });
-      return;
-    }
-
-    setSelectedCells(new Set([key]));
-    setCellAnchor({ rIdx, cIdx });
-  }
-
-  function handleRowToggle(rowIndex: number, rowId: string, event: React.MouseEvent) {
-    setLastClickedRowId(rowId);
-    focusWithoutScroll(gridRef.current);
-    setSelectCycleMode("default");
-
-    if (event.shiftKey && lastRowAnchor != null) {
-      const min = Math.min(lastRowAnchor, rowIndex);
-      const max = Math.max(lastRowAnchor, rowIndex);
-      const next = new Set(selectedRows);
-
-      for (let idx = min; idx <= max; idx += 1) {
-        const row = viewRows[idx];
-        if (!row) continue;
-        next.add(String(row[activeSheet.primaryKey] ?? ""));
-      }
-
-      setSelectedRows(next);
-      return;
-    }
-
-    setSelectedRows((prev) => {
-      const next = new Set(prev);
-      if (next.has(rowId)) next.delete(rowId);
-      else next.add(rowId);
-      return next;
-    });
-
-    setLastRowAnchor(rowIndex);
-  }
-
-  function selectVisibleRows() {
-    const visibleIds = getSelectableRowIds(viewRows);
-    setSelectedRows(new Set(visibleIds));
-    setSelectCycleMode("default");
-  }
-
-  function clearSelectedRows() {
-    setSelectedRows(new Set());
-    setSelectCycleMode("default");
-  }
-
-  function invertVisibleSelection() {
-    const visibleIds = getSelectableRowIds(viewRows);
-    const inverted = new Set<string>();
-
-    for (const rowId of visibleIds) {
-      if (!selectedRows.has(rowId)) {
-        inverted.add(rowId);
-      }
-    }
-
-    setSelectedRows(inverted);
-    setSelectCycleMode("inverted");
-  }
-
-  function handleSelectAllCycle() {
-    const visibleIds = getSelectableRowIds(viewRows);
-
-    if (visibleIds.length === 0) {
-      clearSelectedRows();
-      return;
-    }
-
-    if (selectedRows.size === 0) {
-      selectVisibleRows();
-      return;
-    }
-
-    if (selectedRows.size === visibleIds.length) {
-      clearSelectedRows();
-      return;
-    }
-
-    if (selectCycleMode === "inverted") {
-      clearSelectedRows();
-      return;
-    }
-
-    invertVisibleSelection();
-  }
-
   function toggleHideSelected() {
     if (selectedRows.size > 0) {
       setHiddenRowsByTable((prev) => {
@@ -2762,7 +2617,7 @@ export function HolisticSheet({
   }
 
   async function handlePasteSelection() {
-    const pasteAnchor = currentCellRef.current ?? lastCellAnchor;
+    const pasteAnchor = getCellSelectionAnchor();
     if (!navigator.clipboard?.readText || !pasteAnchor || !canWriteActiveSheet) return;
 
     const text = await navigator.clipboard.readText();
@@ -3922,46 +3777,6 @@ export function HolisticSheet({
     if (!nearRightEdge) return;
 
     startResize(column, event.clientX, event);
-  }
-
-  function moveCellSelectionBy(dr: number, dc: number, withRange: boolean) {
-    if (viewRows.length === 0 || columns.length === 0) return;
-
-    const source = currentCellRef.current ?? lastCellAnchorRef.current ?? { rIdx: 0, cIdx: 0 };
-    const maxRow = Math.max(0, viewRows.length - 1);
-    const maxCol = Math.max(0, columns.length - 1);
-    const nextRow = Math.max(0, Math.min(maxRow, source.rIdx + dr));
-    const nextCol = Math.max(0, Math.min(maxCol, source.cIdx + dc));
-    const anchor = lastCellAnchorRef.current;
-
-    if (withRange) {
-      const rangeAnchor = anchor ?? source;
-      if (!anchor) {
-        setCellAnchor(rangeAnchor);
-      }
-
-      const next = new Set<string>();
-      const rMin = Math.min(rangeAnchor.rIdx, nextRow);
-      const rMax = Math.max(rangeAnchor.rIdx, nextRow);
-      const cMin = Math.min(rangeAnchor.cIdx, nextCol);
-      const cMax = Math.max(rangeAnchor.cIdx, nextCol);
-
-      for (let r = rMin; r <= rMax; r += 1) {
-        for (let c = cMin; c <= cMax; c += 1) {
-          next.add(cellKey(r, c));
-        }
-      }
-      setSelectedCells(next);
-      setCurrentCellAnchor({ rIdx: nextRow, cIdx: nextCol });
-    } else {
-      setSelectedCells(new Set([cellKey(nextRow, nextCol)]));
-      setCellAnchor({ rIdx: nextRow, cIdx: nextCol });
-      setCurrentCellAnchor({ rIdx: nextRow, cIdx: nextCol });
-    }
-
-    const cell = document.getElementById(`grid-cell-${activeSheet.key}-${nextRow}-${nextCol}`);
-    cell?.scrollIntoView({ block: "nearest", inline: "nearest" });
-    focusWithoutScroll(gridRef.current);
   }
 
   useEffect(() => {
@@ -5195,7 +5010,7 @@ export function HolisticSheet({
                       moveCellSelectionBy(0, 1, event.shiftKey);
                     }
 
-                    const targetCell = currentCell ?? lastCellAnchor;
+                    const targetCell = getCellSelectionAnchor();
                     if (event.key === "Enter" && targetCell) {
                       event.preventDefault();
                       const row = viewRows[targetCell.rIdx];

--- a/components/ui-grid/hooks/useGridDrawerState.ts
+++ b/components/ui-grid/hooks/useGridDrawerState.ts
@@ -1,0 +1,38 @@
+import { useCallback, useState } from "react";
+import type { RelationDialogTarget, SheetKey } from "@/components/ui-grid/types";
+
+export type GridRelationDialogState = {
+  sourceColumn: string;
+  targetTable: SheetKey;
+  keyColumn: string;
+  target: RelationDialogTarget;
+};
+
+export function useGridDrawerState() {
+  const [relationDialog, setRelationDialog] = useState<GridRelationDialogState | null>(null);
+  const [relationDialogLoading, setRelationDialogLoading] = useState(false);
+  const [hiddenColumnsDialogOpen, setHiddenColumnsDialogOpen] = useState(false);
+  const [selectionDialogOpen, setSelectionDialogOpen] = useState(false);
+  const [activeFiltersDialogOpen, setActiveFiltersDialogOpen] = useState(false);
+
+  const closeGridDrawers = useCallback(() => {
+    setRelationDialog(null);
+    setHiddenColumnsDialogOpen(false);
+    setSelectionDialogOpen(false);
+    setActiveFiltersDialogOpen(false);
+  }, []);
+
+  return {
+    activeFiltersDialogOpen,
+    closeGridDrawers,
+    hiddenColumnsDialogOpen,
+    relationDialog,
+    relationDialogLoading,
+    selectionDialogOpen,
+    setActiveFiltersDialogOpen,
+    setHiddenColumnsDialogOpen,
+    setRelationDialog,
+    setRelationDialogLoading,
+    setSelectionDialogOpen
+  };
+}

--- a/components/ui-grid/hooks/useGridKeyboardSelection.ts
+++ b/components/ui-grid/hooks/useGridKeyboardSelection.ts
@@ -1,0 +1,312 @@
+import { useCallback, useRef, type MouseEvent as ReactMouseEvent, type RefObject } from "react";
+import type { SheetKey } from "@/components/ui-grid/types";
+import type { CellAnchor, GridSelectionState } from "@/components/ui-grid/hooks/useGridSelection";
+
+type UseGridKeyboardSelectionParams = {
+  activeSheetKey: SheetKey;
+  activeSheetPrimaryKey: string;
+  columns: string[];
+  getSelectableRowIds: (rows: Array<Record<string, unknown>>) => string[];
+  gridRef: RefObject<HTMLDivElement | null>;
+  isConferenceMode: boolean;
+  isEditorMode: boolean;
+  onOpenUpdateForm: (row: Record<string, unknown>) => void | Promise<void>;
+  selection: GridSelectionState;
+  toggleConferenceRow: (rowId: string) => void;
+  viewRows: Array<Record<string, unknown>>;
+};
+
+export function cellKey(rIdx: number, cIdx: number) {
+  return `${rIdx}::${cIdx}`;
+}
+
+export function parseCellKey(value: string): CellAnchor {
+  const [r, c] = value.split("::");
+  return { rIdx: Number(r), cIdx: Number(c) };
+}
+
+function focusGridWithoutScroll(gridRef: RefObject<HTMLDivElement | null>) {
+  gridRef.current?.focus({ preventScroll: true });
+}
+
+export function useGridKeyboardSelection({
+  activeSheetKey,
+  activeSheetPrimaryKey,
+  columns,
+  getSelectableRowIds,
+  gridRef,
+  isConferenceMode,
+  isEditorMode,
+  onOpenUpdateForm,
+  selection,
+  toggleConferenceRow,
+  viewRows
+}: UseGridKeyboardSelectionParams) {
+  const {
+    lastCellAnchor,
+    lastRowAnchor,
+    selectedRows,
+    selectCycleMode,
+    setCurrentCell,
+    setLastCellAnchor,
+    setLastClickedRowId,
+    setLastRowAnchor,
+    setSelectedCells,
+    setSelectedRows,
+    setSelectCycleMode
+  } = selection;
+  const lastCellAnchorRef = useRef<CellAnchor | null>(null);
+  const currentCellRef = useRef<CellAnchor | null>(null);
+
+  const setCellAnchor = useCallback(
+    (next: CellAnchor | null) => {
+      lastCellAnchorRef.current = next;
+      setLastCellAnchor(next);
+    },
+    [setLastCellAnchor]
+  );
+
+  const setCurrentCellAnchor = useCallback(
+    (next: CellAnchor | null) => {
+      currentCellRef.current = next;
+      setCurrentCell(next);
+    },
+    [setCurrentCell]
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedRows(new Set());
+    setSelectedCells(new Set());
+    setCellAnchor(null);
+    setCurrentCellAnchor(null);
+    setLastRowAnchor(null);
+    setSelectCycleMode("default");
+  }, [setCellAnchor, setCurrentCellAnchor, setLastRowAnchor, setSelectCycleMode, setSelectedCells, setSelectedRows]);
+
+  const getCellSelectionAnchor = useCallback(() => currentCellRef.current ?? lastCellAnchorRef.current ?? lastCellAnchor, [lastCellAnchor]);
+
+  const handleCellClick = useCallback(
+    (rIdx: number, cIdx: number, event: ReactMouseEvent) => {
+      focusGridWithoutScroll(gridRef);
+      const row = viewRows[rIdx];
+      const rowId = String(row?.[activeSheetPrimaryKey] ?? "");
+      if (rowId) setLastClickedRowId(rowId);
+
+      if (row && isEditorMode) {
+        void onOpenUpdateForm(row);
+        return;
+      }
+
+      if (row && isConferenceMode) {
+        toggleConferenceRow(rowId);
+        return;
+      }
+
+      const key = cellKey(rIdx, cIdx);
+      setCurrentCellAnchor({ rIdx, cIdx });
+
+      const anchor = lastCellAnchorRef.current ?? lastCellAnchor;
+      if (event.shiftKey && anchor) {
+        const next = new Set<string>();
+        const rMin = Math.min(anchor.rIdx, rIdx);
+        const rMax = Math.max(anchor.rIdx, rIdx);
+        const cMin = Math.min(anchor.cIdx, cIdx);
+        const cMax = Math.max(anchor.cIdx, cIdx);
+
+        for (let r = rMin; r <= rMax; r += 1) {
+          for (let c = cMin; c <= cMax; c += 1) {
+            next.add(cellKey(r, c));
+          }
+        }
+
+        setSelectedCells(next);
+        return;
+      }
+
+      if (event.metaKey || event.ctrlKey) {
+        setSelectedCells((prev) => {
+          const next = new Set(prev);
+          if (next.has(key)) next.delete(key);
+          else next.add(key);
+          return next;
+        });
+        setCellAnchor({ rIdx, cIdx });
+        return;
+      }
+
+      setSelectedCells(new Set([key]));
+      setCellAnchor({ rIdx, cIdx });
+    },
+    [
+      activeSheetPrimaryKey,
+      gridRef,
+      isConferenceMode,
+      isEditorMode,
+      lastCellAnchor,
+      onOpenUpdateForm,
+      setCellAnchor,
+      setCurrentCellAnchor,
+      setLastClickedRowId,
+      setSelectedCells,
+      toggleConferenceRow,
+      viewRows
+    ]
+  );
+
+  const handleRowToggle = useCallback(
+    (rowIndex: number, rowId: string, event: ReactMouseEvent) => {
+      setLastClickedRowId(rowId);
+      focusGridWithoutScroll(gridRef);
+      setSelectCycleMode("default");
+
+      if (event.shiftKey && lastRowAnchor != null) {
+        const min = Math.min(lastRowAnchor, rowIndex);
+        const max = Math.max(lastRowAnchor, rowIndex);
+        const next = new Set(selectedRows);
+
+        for (let idx = min; idx <= max; idx += 1) {
+          const row = viewRows[idx];
+          if (!row) continue;
+          next.add(String(row[activeSheetPrimaryKey] ?? ""));
+        }
+
+        setSelectedRows(next);
+        return;
+      }
+
+      setSelectedRows((prev) => {
+        const next = new Set(prev);
+        if (next.has(rowId)) next.delete(rowId);
+        else next.add(rowId);
+        return next;
+      });
+
+      setLastRowAnchor(rowIndex);
+    },
+    [
+      activeSheetPrimaryKey,
+      gridRef,
+      lastRowAnchor,
+      selectedRows,
+      setLastClickedRowId,
+      setLastRowAnchor,
+      setSelectedRows,
+      setSelectCycleMode,
+      viewRows
+    ]
+  );
+
+  const selectVisibleRows = useCallback(() => {
+    const visibleIds = getSelectableRowIds(viewRows);
+    setSelectedRows(new Set(visibleIds));
+    setSelectCycleMode("default");
+  }, [getSelectableRowIds, setSelectedRows, setSelectCycleMode, viewRows]);
+
+  const clearSelectedRows = useCallback(() => {
+    setSelectedRows(new Set());
+    setSelectCycleMode("default");
+  }, [setSelectedRows, setSelectCycleMode]);
+
+  const invertVisibleSelection = useCallback(() => {
+    const visibleIds = getSelectableRowIds(viewRows);
+    const inverted = new Set<string>();
+
+    for (const rowId of visibleIds) {
+      if (!selectedRows.has(rowId)) {
+        inverted.add(rowId);
+      }
+    }
+
+    setSelectedRows(inverted);
+    setSelectCycleMode("inverted");
+  }, [getSelectableRowIds, selectedRows, setSelectedRows, setSelectCycleMode, viewRows]);
+
+  const handleSelectAllCycle = useCallback(() => {
+    const visibleIds = getSelectableRowIds(viewRows);
+
+    if (visibleIds.length === 0) {
+      clearSelectedRows();
+      return;
+    }
+
+    if (selectedRows.size === 0) {
+      selectVisibleRows();
+      return;
+    }
+
+    if (selectedRows.size === visibleIds.length) {
+      clearSelectedRows();
+      return;
+    }
+
+    if (selectCycleMode === "inverted") {
+      clearSelectedRows();
+      return;
+    }
+
+    invertVisibleSelection();
+  }, [
+    clearSelectedRows,
+    getSelectableRowIds,
+    invertVisibleSelection,
+    selectCycleMode,
+    selectVisibleRows,
+    selectedRows.size,
+    viewRows
+  ]);
+
+  const moveCellSelectionBy = useCallback(
+    (dr: number, dc: number, withRange: boolean) => {
+      if (viewRows.length === 0 || columns.length === 0) return;
+
+      const source = currentCellRef.current ?? lastCellAnchorRef.current ?? { rIdx: 0, cIdx: 0 };
+      const maxRow = Math.max(0, viewRows.length - 1);
+      const maxCol = Math.max(0, columns.length - 1);
+      const nextRow = Math.max(0, Math.min(maxRow, source.rIdx + dr));
+      const nextCol = Math.max(0, Math.min(maxCol, source.cIdx + dc));
+      const anchor = lastCellAnchorRef.current;
+
+      if (withRange) {
+        const rangeAnchor = anchor ?? source;
+        if (!anchor) {
+          setCellAnchor(rangeAnchor);
+        }
+
+        const next = new Set<string>();
+        const rMin = Math.min(rangeAnchor.rIdx, nextRow);
+        const rMax = Math.max(rangeAnchor.rIdx, nextRow);
+        const cMin = Math.min(rangeAnchor.cIdx, nextCol);
+        const cMax = Math.max(rangeAnchor.cIdx, nextCol);
+
+        for (let r = rMin; r <= rMax; r += 1) {
+          for (let c = cMin; c <= cMax; c += 1) {
+            next.add(cellKey(r, c));
+          }
+        }
+        setSelectedCells(next);
+        setCurrentCellAnchor({ rIdx: nextRow, cIdx: nextCol });
+      } else {
+        setSelectedCells(new Set([cellKey(nextRow, nextCol)]));
+        setCellAnchor({ rIdx: nextRow, cIdx: nextCol });
+        setCurrentCellAnchor({ rIdx: nextRow, cIdx: nextCol });
+      }
+
+      const cell = document.getElementById(`grid-cell-${activeSheetKey}-${nextRow}-${nextCol}`);
+      cell?.scrollIntoView({ block: "nearest", inline: "nearest" });
+      focusGridWithoutScroll(gridRef);
+    },
+    [activeSheetKey, columns.length, gridRef, setCellAnchor, setCurrentCellAnchor, setSelectedCells, viewRows.length]
+  );
+
+  return {
+    clearSelectedRows,
+    clearSelection,
+    getCellSelectionAnchor,
+    handleCellClick,
+    handleRowToggle,
+    handleSelectAllCycle,
+    invertVisibleSelection,
+    moveCellSelectionBy,
+    selectVisibleRows
+  };
+}

--- a/components/ui-grid/hooks/useGridScrollSync.ts
+++ b/components/ui-grid/hooks/useGridScrollSync.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useRef, type UIEvent } from "react";
+import type { SheetKey, StoredGridScroll } from "@/components/ui-grid/types";
+import {
+  clampGridScrollToNode,
+  normalizeStoredGridScroll,
+  persistGridScrollState
+} from "@/components/ui-grid/hooks/useGridStoredState";
+
+type UseGridScrollSyncParams = {
+  activeSheetKey: SheetKey;
+  isActiveSheetStateHydrated: boolean;
+  rowCount: number;
+  showGridPanel: boolean;
+  tablePixelWidth: number;
+};
+
+export function useGridScrollSync({
+  activeSheetKey,
+  isActiveSheetStateHydrated,
+  rowCount,
+  showGridPanel,
+  tablePixelWidth
+}: UseGridScrollSyncParams) {
+  const gridRef = useRef<HTMLDivElement>(null);
+  const gridScrollRestoreRef = useRef<StoredGridScroll>({ left: 0, top: 0 });
+  const gridScrollRestoringRef = useRef(false);
+  const gridScrollWriteFrameRef = useRef<number | null>(null);
+
+  const prepareGridScrollRestore = useCallback((storedScroll: Partial<StoredGridScroll> | null | undefined) => {
+    gridScrollRestoreRef.current = normalizeStoredGridScroll(storedScroll);
+    gridScrollRestoringRef.current = true;
+  }, []);
+
+  const handleGridScroll = useCallback(
+    (event: UIEvent<HTMLDivElement>) => {
+      if (!isActiveSheetStateHydrated) return;
+      if (gridScrollRestoringRef.current) return;
+
+      const next = normalizeStoredGridScroll({
+        left: event.currentTarget.scrollLeft,
+        top: event.currentTarget.scrollTop
+      });
+
+      gridScrollRestoreRef.current = next;
+
+      if (gridScrollWriteFrameRef.current != null) {
+        window.cancelAnimationFrame(gridScrollWriteFrameRef.current);
+      }
+
+      gridScrollWriteFrameRef.current = window.requestAnimationFrame(() => {
+        persistGridScrollState(activeSheetKey, next);
+        gridScrollWriteFrameRef.current = null;
+      });
+    },
+    [activeSheetKey, isActiveSheetStateHydrated]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (gridScrollWriteFrameRef.current != null) {
+        window.cancelAnimationFrame(gridScrollWriteFrameRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!showGridPanel || !isActiveSheetStateHydrated) return;
+
+    const node = gridRef.current;
+    if (!node) return;
+
+    const desiredScroll = normalizeStoredGridScroll(gridScrollRestoreRef.current);
+    let frame = 0;
+    let attempts = 0;
+
+    const restoreScroll = () => {
+      attempts += 1;
+      const clampedScroll = clampGridScrollToNode(node, desiredScroll);
+      const nextLeft = clampedScroll.left;
+      const nextTop = clampedScroll.top;
+
+      if (Math.abs(node.scrollLeft - nextLeft) > 1) {
+        node.scrollLeft = nextLeft;
+      }
+
+      if (Math.abs(node.scrollTop - nextTop) > 1) {
+        node.scrollTop = nextTop;
+      }
+
+      const needsRetry =
+        attempts < 60 && (Math.abs(node.scrollLeft - desiredScroll.left) > 1 || Math.abs(node.scrollTop - desiredScroll.top) > 1);
+
+      if (needsRetry) {
+        frame = window.requestAnimationFrame(restoreScroll);
+        return;
+      }
+
+      gridScrollRestoringRef.current = false;
+    };
+
+    frame = window.requestAnimationFrame(restoreScroll);
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+    };
+  }, [activeSheetKey, isActiveSheetStateHydrated, rowCount, showGridPanel, tablePixelWidth]);
+
+  return {
+    gridRef,
+    handleGridScroll,
+    prepareGridScrollRestore
+  };
+}

--- a/components/ui-grid/hooks/useGridSelection.ts
+++ b/components/ui-grid/hooks/useGridSelection.ts
@@ -34,3 +34,5 @@ export function useGridSelection() {
     setSelectCycleMode
   };
 }
+
+export type GridSelectionState = ReturnType<typeof useGridSelection>;

--- a/docs/project-control/work-records/2026-05-11-holistic-sheet-wave2.md
+++ b/docs/project-control/work-records/2026-05-11-holistic-sheet-wave2.md
@@ -1,0 +1,17 @@
+# Holistic Sheet Wave 2
+
+## Context
+
+Wave 2 continues the extraction of `components/ui-grid/holistic-sheet.tsx` on branch `refactor/holistic-sheet-wave2`.
+
+## Diff Contract
+
+- Objective: extract 2 to 4 focused hooks from `HolisticSheet` while preserving the public component API.
+- Scope: `components/ui-grid/holistic-sheet.tsx`, new files under `components/ui-grid/hooks/`, and this work record.
+- Out of scope: schema changes, API changes, dependency additions, broad rewrites, and inline edit extraction if refs or optimistic mutation surfaces become too wide.
+- Validation: after each hook extraction, run `npm run test:unit` and `npx tsc --noEmit`; revert the extraction immediately if either fails.
+- Rollback: revert the extraction commit for the failing hook.
+
+## Reuse Decision
+
+Existing Wave 1 hooks use local `useState` or small effect ownership under `components/ui-grid/hooks/`. Wave 2 will follow that style instead of adding a new abstraction layer outside `ui-grid`.


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 2 (Wave 2)
- Escopo tocado: `components/ui-grid/holistic-sheet.tsx`, `components/ui-grid/hooks/`

## Resumo
**Continuação da Wave 1 PR #32.** Codex Wave 1 extraiu 4 hooks e parou deliberadamente em seleção por teclado / drawers / refs porque cruzavam refs/layout/mutações. Wave 2 ataca esses cortes com cuidado extra. Trabalho conduzido por **Codex gpt-5.5 xhigh** em worktree isolado, com 264k tokens consumidos.

3 hooks novos em `components/ui-grid/hooks/`:

| Commit | Hook | Responsabilidade |
|---|---|---|
| `772c604` | `useGridScrollSync` | sincronização de scroll (gridRef + handlers) |
| `d74a71a` | `useGridKeyboardSelection` | seleção por teclado (shift/ctrl/arrow) |
| `915989e` | `useGridDrawerState` | estado dos drawers laterais |

+ work record em `docs/project-control/work-records/2026-05-11-holistic-sheet-wave2.md`.

## Metas mínimas de qualidade
### Linhas antes/depois
- `holistic-sheet.tsx`: **7.176 → 6.920** (-256 linhas locais; somando Wave 1 + 2: 7.402 → 6.920, ~6.5% de redução modularizando o monólito)

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0
- `npx tsc --noEmit`: exit 0 após cada extração
- `any` introduzidos: 0

### Evidência de testes
- [x] Testes unitários: **16 arquivos / 94 testes passando** (após cada commit)
- [x] `npm run build`: passou (exit 0) — warnings pre-existentes permanecem
- [x] E2E: recomendado `npm run test:e2e` antes do merge — refactor mexe em comportamento de seleção
- Comandos:
  ```txt
  npm run test:unit  → 94/94 ✅ após cada commit
  npx tsc --noEmit   → exit 0
  npm run build      → exit 0
  ```

### Tempo de review
- Tempo total estimado: 35 min (3 commits + work record, hooks isolados mas refs ainda complexas)
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 2
- [x] Segurança validada (sem mudança de auth/policy)
- [x] Regressão visual validada (API pública preservada)
- [x] Performance validada (mesmas renderizações)

## Observações finais
- **Parada deliberada (Wave 3)**: edição inline, queue de persistência, dialogs renderizados e refs profundas de layout. Esses cortes precisam de teste manual extensivo antes da extração.
- Riscos residuais:
  - **Seleção por teclado**: caminho mais frágil (shift+click, ctrl+click, arrow keys). Vale smoke manual.
  - **Drawers**: side-effects ao abrir/fechar.
  - **Scroll sync**: aceita `RefObject<HTMLElement>` — comportamento de restauração de scroll precisa ser validado em página com muitas linhas.
- Plano de rollback: `git revert 915989e d74a71a 772c604`

Commits sequenciais: `772c604` → `d74a71a` → `915989e` (+ work record)
