### PR TITLE
chore(ci): add lint typecheck test-unit build checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tsc --noEmit
+        run: npx tsc --noEmit
+
+  test-unit:
+    name: Unit tests (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run vitest
+        run: npm run test:unit
+
+  build:
+    name: Next build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Placeholder env vars — runtime Supabase access is lazy (see
+      # lib/supabase/{client,server}.ts and lib/api/supabase-admin.ts: env
+      # is only read inside the create* functions, never at module load).
+      # These keep `next build` happy if any future code adds a build-time
+      # guard; they are NOT real credentials.
+      - name: Run next build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: http://localhost:54321
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder-anon-key
+          NEXT_PUBLIC_SITE_URL: http://localhost:3000
+        run: npm run build


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 1 (DevX / qualidade)
- Escopo tocado: `.github/workflows/ci.yml` (novo)

## Resumo
**Gotcha da auditoria gpt-5.5 xhigh.** AGENTS.md lista "CI só roda `metrics:gate`" como risco — bugs de tipo/lint/teste só pegam em prod. Esta PR adiciona um workflow paralelo com 4 jobs.

Novo workflow `.github/workflows/ci.yml` (93 linhas, YAML válido):

| Job | Comando | Tempo esperado |
|---|---|---|
| `lint` | `npm run lint` | ~30s |
| `typecheck` | `npx tsc --noEmit` | ~40s |
| `test-unit` | `npm run test:unit` | ~10s |
| `build` | `npm run build` (com placeholders de env) | ~60s |

Triggers: `pull_request` (opened/edited/synchronize/reopened) + `push: main`.

## Metas mínimas de qualidade
### Linhas antes/depois
- Novo arquivo: `.github/workflows/ci.yml` (+93)
- `package.json` não tocado (uso `npx tsc --noEmit` direto, sem adicionar script)

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0 (yaml puro)
- Validação de sintaxe: `npx -p js-yaml js-yaml .github/workflows/ci.yml` ✅

### Evidência de testes
- [x] N/A — somente configuração de CI
- Validação local sugerida via `act` (`https://github.com/nektos/act`):
  ```bash
  act pull_request -W .github/workflows/ci.yml -j lint
  act pull_request -W .github/workflows/ci.yml -j build
  ```

### Tempo de review
- Tempo total estimado: 10 min
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 1
- [x] Segurança validada (sem secrets no YAML, apenas placeholders públicos)
- [x] Regressão visual validada (N/A)
- [x] Performance validada (jobs em paralelo)

## Decisões
- **Node 22 + `cache: npm`** — bate com `refactor-quality-gate.yml` existente. Sem `.nvmrc` no projeto.
- **Build INCLUÍDO**: env do Supabase é lido **lazy** em todos os call-sites (`lib/supabase/client.ts:26`, `lib/supabase/server.ts:5`, `lib/api/supabase-admin.ts:6`). Logo `next build` não precisa de credenciais reais — usei placeholders óbvios (`http://localhost:54321`, `ci-placeholder-anon-key`).
- **E2E (Playwright) deliberadamente fora** — exige Supabase real e dev server em `127.0.0.1:3100`. Fora do escopo "lint+unit+typecheck+build".
- **`metrics:gate` intacto** em `.github/workflows/refactor-quality-gate.yml` (arquivo separado, sem conflito).

## Observações finais
- Riscos residuais:
  1. **Build pode falhar no primeiro run** se algum módulo tiver acesso eager a env não-coberto pela varredura. Mitigação: adicionar env var faltante ao step de build se aparecer.
  2. **CI fica mais lento** — `npm ci` roda 4× em paralelo. Mitigação futura: extrair install para job compartilhado.
  3. **AGENTS.md §90** ("CI roda só `metrics:gate`") fica desatualizado após merge. Edição follow-up.
  4. **Branch protection** automática NÃO é aplicada — precisa configurar manualmente em Settings → Branches → main → Require status checks.
- Plano de rollback: `git revert e2ff4eb`

Commit: `e2ff4eb`
