### PR TITLE
fix(playground): respect grid sizes on print and expand FK in filter options

### DIFF
--- a/components/playground/hooks/use-playground-feed-data.ts
+++ b/components/playground/hooks/use-playground-feed-data.ts
@@ -262,6 +262,7 @@ export function usePlaygroundFeedData(params: {
     targets,
     recordsByTargetId,
     displayCells,
+    relationDisplayLookupByTargetId,
     firstError,
     isRefreshing: refreshingCount > 0,
     refreshAll,

--- a/components/playground/playground-workspace.tsx
+++ b/components/playground/playground-workspace.tsx
@@ -15,6 +15,7 @@ import { SHEETS } from "@/components/ui-grid/config";
 import {
   EMPTY_FILTER_LITERAL,
   RELATION_BY_SHEET_COLUMN,
+  resolveDisplayValueFromLookup,
   toFilterSelectionLabel
 } from "@/components/ui-grid/core/grid-rules";
 import { HolisticChooserDialog, type HolisticChooserOption } from "@/components/ui-grid/sheet-chrome";
@@ -210,13 +211,25 @@ function createFragmentId(feedId: string, sourceColumn: string, literal: string,
   return candidate;
 }
 
-function buildLocalFeedFilterOptions(rows: Array<Record<string, unknown>>, column: string): PlaygroundFacetOption[] {
+function buildLocalFeedFilterOptions(
+  rows: Array<Record<string, unknown>>,
+  column: string,
+  relationDisplayLookup: Record<string, Record<string, unknown>> = {}
+): PlaygroundFacetOption[] {
   const bucket = new Map<string, { label: string; count: number }>();
+  const hasFkExpansion = column in relationDisplayLookup;
 
   for (const row of rows) {
     const rawValue = row[column];
     const literal = rawValue == null || rawValue === "" ? EMPTY_FILTER_LITERAL : String(rawValue);
-    const label = literal === EMPTY_FILTER_LITERAL ? "(vazio)" : formatPlaygroundFeedValue(rawValue);
+    let label: string;
+    if (literal === EMPTY_FILTER_LITERAL) {
+      label = "(vazio)";
+    } else if (hasFkExpansion) {
+      label = formatPlaygroundFeedValue(resolveDisplayValueFromLookup(row, column, relationDisplayLookup));
+    } else {
+      label = formatPlaygroundFeedValue(rawValue);
+    }
     const current = bucket.get(literal);
 
     if (current) {
@@ -238,6 +251,23 @@ function buildLocalFeedFilterOptions(rows: Array<Record<string, unknown>>, colum
       if (right.literal === EMPTY_FILTER_LITERAL) return 1;
       return left.label.localeCompare(right.label, "pt-BR", { numeric: true, sensitivity: "base" });
     });
+}
+
+function applyRelationDisplayToFacetOptions(
+  options: PlaygroundFacetOption[],
+  column: string,
+  relationDisplayLookup: Record<string, Record<string, unknown>>
+): PlaygroundFacetOption[] {
+  const mapForColumn = relationDisplayLookup[column];
+  if (!mapForColumn) return options;
+
+  return options.map((option) => {
+    if (option.literal === EMPTY_FILTER_LITERAL) return option;
+    if (!(option.literal in mapForColumn)) return option;
+    const display = mapForColumn[option.literal];
+    if (display == null) return option;
+    return { ...option, label: formatPlaygroundFeedValue(display) };
+  });
 }
 
 function describeFeedFilterExpression(expressionRaw: string) {
@@ -470,21 +500,21 @@ function buildPrintDocument(params: {
 
   const gridBorder = params.showGridLines ? "1px solid #cbd5e1" : "0";
   const rowMarkup = rowIndexes.map((row) => {
+    const rowHeight = getRowHeight(params.page, row);
     const cells = columnIndexes
       .map((col) => {
         const cell = getCell(params.page, row, col);
         const cellStyle = [
-          `height:${getRowHeight(params.page, row)}px;`,
           cell.style?.background ? `background-color:${cell.style.background} !important;` : "",
           cell.style?.color ? `color:${cell.style.color} !important;` : "",
           cell.style?.bold ? "font-weight:700;" : ""
         ].join("");
 
-        return `<td style="${cellStyle}">${escapeHtml(cell.value || " ")}</td>`;
+        return `<td${cellStyle ? ` style="${cellStyle}"` : ""}>${escapeHtml(cell.value || " ")}</td>`;
       })
       .join("");
 
-    return `<tr>${params.showSheetIndexes ? `<th>${row + 1}</th>` : ""}${cells}</tr>`;
+    return `<tr style="height:${rowHeight}px;">${params.showSheetIndexes ? `<th>${row + 1}</th>` : ""}${cells}</tr>`;
   });
 
   const colgroupMarkup = columnIndexes
@@ -552,12 +582,15 @@ function buildPrintDocument(params: {
 
       th,
       td {
+        box-sizing: border-box;
         border: ${gridBorder};
-        padding: 6px 8px;
+        padding: 0 10px;
         font-size: 12px;
+        font-weight: 500;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+        vertical-align: middle;
       }
 
       thead th,
@@ -770,6 +803,7 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
     targets: feedDataTargets,
     isRefreshing: feedDataRefreshing,
     recordsByTargetId: feedDataByTargetId,
+    relationDisplayLookupByTargetId: feedRelationDisplayLookupByTargetId,
     refreshAll: refreshAllFeedData,
     refreshFeed: refreshFeedData
   } = usePlaygroundFeedData({ page: activePage, requestAuth, relationCache });
@@ -1339,7 +1373,11 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
 
     const { top, left, maxHeight } = getClampedPopoverPosition(rect);
     const label = target.columnLabels[column] ?? column;
-    const localOptions = buildLocalFeedFilterOptions(feedDataByTargetId[targetId]?.rows ?? [], column);
+    const localOptions = buildLocalFeedFilterOptions(
+      feedDataByTargetId[targetId]?.rows ?? [],
+      column,
+      feedRelationDisplayLookupByTargetId[targetId] ?? {}
+    );
 
     setFeedFilterSearch("");
     setFeedFilterDraftValues(parseFeedFilterSelection(target.query.filters[column] ?? ""));
@@ -1427,7 +1465,13 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
     if (!target) return;
 
     const sourceColumn = target.columns[0] ?? "";
-    const localOptions = sourceColumn ? buildLocalFeedFilterOptions(feedDataByTargetId[feedId]?.rows ?? [], sourceColumn) : [];
+    const localOptions = sourceColumn
+      ? buildLocalFeedFilterOptions(
+          feedDataByTargetId[feedId]?.rows ?? [],
+          sourceColumn,
+          feedRelationDisplayLookupByTargetId[feedId] ?? {}
+        )
+      : [];
 
     setFragmentDialog({
       feedId,
@@ -1632,7 +1676,13 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
     if (!feedFilterPopover || !activeFeedFilterTarget) return;
 
     const controller = new AbortController();
-    const localOptions = buildLocalFeedFilterOptions(feedDataByTargetId[feedFilterPopover.targetId]?.rows ?? [], feedFilterPopover.column);
+    const targetRelationDisplayLookup =
+      feedRelationDisplayLookupByTargetId[feedFilterPopover.targetId] ?? {};
+    const localOptions = buildLocalFeedFilterOptions(
+      feedDataByTargetId[feedFilterPopover.targetId]?.rows ?? [],
+      feedFilterPopover.column,
+      targetRelationDisplayLookup
+    );
     const facetCacheKey = `${activeFeedFilterTarget.id}:${activeFeedFilterRequestKey}:${feedFilterPopover.column}`;
     const cachedOptions = feedFacetCacheRef.current.get(facetCacheKey);
 
@@ -1655,8 +1705,13 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
       signal: controller.signal
     })
       .then((payload) => {
-        feedFacetCacheRef.current.set(facetCacheKey, payload.options);
-        setFeedFilterOptions(payload.options);
+        const expandedOptions = applyRelationDisplayToFacetOptions(
+          payload.options,
+          feedFilterPopover.column,
+          targetRelationDisplayLookup
+        );
+        feedFacetCacheRef.current.set(facetCacheKey, expandedOptions);
+        setFeedFilterOptions(expandedOptions);
       })
       .catch((filterError) => {
         if (filterError instanceof DOMException && filterError.name === "AbortError") return;
@@ -1673,13 +1728,26 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
       });
 
     return () => controller.abort();
-  }, [activeFeedFilterRequestKey, activeFeedFilterTarget, feedDataByTargetId, feedFilterPopover, requestAuth]);
+  }, [
+    activeFeedFilterRequestKey,
+    activeFeedFilterTarget,
+    feedDataByTargetId,
+    feedFilterPopover,
+    feedRelationDisplayLookupByTargetId,
+    requestAuth
+  ]);
 
   useEffect(() => {
     if (!fragmentDialogFeedId || !fragmentDialogSourceColumn || !activeFragmentTarget) return;
 
     const controller = new AbortController();
-    const localOptions = buildLocalFeedFilterOptions(feedDataByTargetId[fragmentDialogFeedId]?.rows ?? [], fragmentDialogSourceColumn);
+    const fragmentRelationDisplayLookup =
+      feedRelationDisplayLookupByTargetId[fragmentDialogFeedId] ?? {};
+    const localOptions = buildLocalFeedFilterOptions(
+      feedDataByTargetId[fragmentDialogFeedId]?.rows ?? [],
+      fragmentDialogSourceColumn,
+      fragmentRelationDisplayLookup
+    );
     const facetCacheKey = `${activeFragmentTarget.id}:${buildPlaygroundFeedRequestKey(activeFragmentTarget)}:${fragmentDialogSourceColumn}`;
     const cachedOptions = feedFacetCacheRef.current.get(facetCacheKey);
 
@@ -1716,12 +1784,17 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
       signal: controller.signal
     })
       .then((payload) => {
-        feedFacetCacheRef.current.set(facetCacheKey, payload.options);
+        const expandedOptions = applyRelationDisplayToFacetOptions(
+          payload.options,
+          fragmentDialogSourceColumn,
+          fragmentRelationDisplayLookup
+        );
+        feedFacetCacheRef.current.set(facetCacheKey, expandedOptions);
         setFragmentDialog((current) =>
           current && current.feedId === fragmentDialogFeedId && current.sourceColumn === fragmentDialogSourceColumn
             ? {
                 ...current,
-                options: payload.options
+                options: expandedOptions
               }
             : current
         );
@@ -1748,7 +1821,14 @@ export function PlaygroundWorkspace({ actor, accessToken, devRole, onSignOut }: 
       });
 
     return () => controller.abort();
-  }, [activeFragmentTarget, feedDataByTargetId, fragmentDialogFeedId, fragmentDialogSourceColumn, requestAuth]);
+  }, [
+    activeFragmentTarget,
+    feedDataByTargetId,
+    feedRelationDisplayLookupByTargetId,
+    fragmentDialogFeedId,
+    fragmentDialogSourceColumn,
+    requestAuth
+  ]);
 
   useEffect(() => {
     const tables = new Set<SheetKey>();


### PR DESCRIPTION
## Contexto da fase
- Fase do roadmap: Fase 2 (UX / correção de bugs)
- Escopo tocado: `components/playground/playground-workspace.tsx`, `components/playground/hooks/use-playground-feed-data.ts`

## Resumo
Dois bugs reportados no Playground:

### Bug 1 — Impressão não respeitando sizes do grid
O CSS de impressão aplicava `padding: 6px 8px` por célula, inflando a altura visível para além do `getRowHeight` configurado. Cada `<td>` ficava com `30 + 12 = 42px` mesmo com altura declarada de 30px.

**Fix**: alinhar o CSS de impressão ao comportamento on-screen do `.playground-cell-value`:
- `padding: 0 10px` (apenas horizontal, igual a tela)
- `box-sizing: border-box` (explícito)
- `vertical-align: middle` (centralização vertical sem padding)
- `height` move do `<td>` pro `<tr>` — assim `getRowHeight` é respeitado direto.

### Bug 2 — Filtros com FK expandida mostram valor raw
Colunas com FK expandida (via `displayColumnOverrides`) eram renderizadas na grid pelo `displayValue` (ex: `cliente_nome="João"`), mas o popover de filtro listava o `literal` raw (ex: `42`).

**Fix em duas pontas**:
1. **Local options** (`buildLocalFeedFilterOptions`) — agora aceita opcional `relationDisplayLookup` e resolve `label` via `resolveDisplayValueFromLookup`. Literal continua sendo a FK raw (porque é o que vai pro filtro Postgres).
2. **Server options** — adicionado `applyRelationDisplayToFacetOptions` para reescrever labels do payload retornado por `/api/v1/grid/<table>/facets`, mantendo literal intacto. Cache do filtro também passa pelos labels expandidos.
3. **Hook** — `usePlaygroundFeedData` agora expõe `relationDisplayLookupByTargetId` (já existia internamente para renderização de células).

Todos os 4 call sites de `buildLocalFeedFilterOptions` (popover, fragmentDialog, etc.) recebem o lookup do target apropriado.

## Metas mínimas de qualidade
### Linhas antes/depois
- `components/playground/playground-workspace.tsx`: **+96 / -16** (97 insertions, 16 deletions)
- `components/playground/hooks/use-playground-feed-data.ts`: **+1 / -0**
- Total: **+97 / -16** em 2 arquivos

### Delta lint warnings
- Base: 0 / Atual: 0 / Delta: 0
- `npx tsc --noEmit`: limpo
- `any` introduzidos: 0

### Evidência de testes
- [x] Testes unitários: **154/154 passando** (20 arquivos)
- [x] E2E: recomendado smoke manual do print + filtros FK em desenvolvimento
- Comandos:
  ```txt
  npm run test:unit  → 154/154 ✅
  npx tsc --noEmit   → exit 0
  ```

### Tempo de review
- Tempo total estimado: 20 min
- Nº de revisores: 1

## Checklist de risco por fase
### Fase 2
- [x] Segurança validada (apenas formatação de label client-side; literal de filtro inalterado)
- [x] Regressão visual validada (print agora bate com grid; filtro mantém comportamento de query)
- [x] Performance validada (build de map O(1) por opção; sem novas chamadas de rede)

## Smoke test manual sugerido
1. **Print**: configurar grid com algumas linhas de altura customizada (não-padrão), abrir o diálogo de impressão e verificar que as alturas no preview de impressão batem.
2. **Filtro com FK**: alimentar um feed que tenha coluna FK (ex: `carros.modelo_id`), expandir a FK pra mostrar `nome_modelo`, abrir filtro nessa coluna e confirmar que as opções listadas mostram o nome (não o id).

## Observações finais
- Riscos residuais:
  - **Server-side facets** ainda retornam labels raw — o fix é client-side. Se um futuro consumidor da rota `/api/v1/grid/<table>/facets` quiser labels resolvidos diretamente, vale considerar expansão server-side (JOIN na tabela relacionada). Fora do escopo aqui.
  - **Cache de facets** agora armazena labels já expandidos por target+column. Se o display override mudar, o cache do popover ainda usa a versão antiga até a próxima abertura. Aceitável porque o cache é per-popover-open via `feedFacetCacheRef`.
  - Print mantém `font-weight: 500` como default (matching screen). Bold continua override via `cell.style.bold`.
- Plano de rollback: `git revert 0f5332b`

Commit: `0f5332b`
