### PR TITLE
feat(vendas): integra fluxo de venda ao grid de carros (criar + conflito)

### DIFF
--- a/app/api/v1/vendas/route.ts
+++ b/app/api/v1/vendas/route.ts
@@ -15,7 +15,8 @@ export async function GET(req: NextRequest) {
       page,
       pageSize,
       estadoVenda: req.nextUrl.searchParams.get("estado_venda"),
-      vendedorAuthUserId: req.nextUrl.searchParams.get("vendedor_auth_user_id")
+      vendedorAuthUserId: req.nextUrl.searchParams.get("vendedor_auth_user_id"),
+      carroId: req.nextUrl.searchParams.get("carro_id")
     });
 
     return apiOk(result.rows, {

--- a/components/ui-grid/api.ts
+++ b/components/ui-grid/api.ts
@@ -320,6 +320,30 @@ export async function deleteSheetRow(params: {
   return parseApi<{ deleted: boolean; id: string }>(response);
 }
 
+export type CreateVendaQuickPayload = {
+  carro_id: string;
+  vendedor_auth_user_id: string;
+  forma_pagamento: "a_vista" | "financiado" | "consorcio" | "parcelado" | "misto";
+  valor_total?: number | null;
+  valor_entrada?: number | null;
+  comprador_nome?: string | null;
+  comprador_documento?: string | null;
+  observacao?: string | null;
+};
+
+export async function createVenda(params: {
+  requestAuth: RequestAuth;
+  payload: CreateVendaQuickPayload;
+}) {
+  const response = await fetchWithTimeout("/api/v1/vendas", {
+    method: "POST",
+    headers: buildRequestHeaders(params.requestAuth),
+    body: JSON.stringify(params.payload)
+  });
+
+  return parseApi<Record<string, unknown>>(response);
+}
+
 export async function fetchLookups(requestAuth: RequestAuth) {
   const response = await fetchWithTimeout("/api/v1/lookups", {
     cache: "no-store",

--- a/components/ui-grid/api.ts
+++ b/components/ui-grid/api.ts
@@ -344,6 +344,48 @@ export async function createVenda(params: {
   return parseApi<Record<string, unknown>>(response);
 }
 
+export type VendaConcluidaRow = {
+  id: string;
+  carro_id: string;
+  estado_venda: string;
+  data_venda: string | null;
+  valor_total: number | null;
+  comprador_nome: string | null;
+  forma_pagamento: string | null;
+  vendedor_auth_user_id: string | null;
+};
+
+export async function listVendasByCarro(params: {
+  requestAuth: RequestAuth;
+  carroId: string;
+  estadoVenda?: "concluida" | "cancelada" | "obsoleta";
+}) {
+  const query = new URLSearchParams();
+  query.set("carro_id", params.carroId);
+  query.set("page_size", "20");
+  if (params.estadoVenda) query.set("estado_venda", params.estadoVenda);
+
+  const response = await fetchWithTimeout(`/api/v1/vendas?${query.toString()}`, {
+    headers: buildRequestHeaders(params.requestAuth)
+  });
+
+  return parseApi<VendaConcluidaRow[]>(response);
+}
+
+export async function updateVendaEstado(params: {
+  requestAuth: RequestAuth;
+  id: string;
+  estadoVenda: "concluida" | "cancelada" | "obsoleta";
+}) {
+  const response = await fetchWithTimeout(`/api/v1/vendas/${params.id}`, {
+    method: "PATCH",
+    headers: buildRequestHeaders(params.requestAuth),
+    body: JSON.stringify({ estado_venda: params.estadoVenda })
+  });
+
+  return parseApi<Record<string, unknown>>(response);
+}
+
 export async function fetchLookups(requestAuth: RequestAuth) {
   const response = await fetchWithTimeout("/api/v1/lookups", {
     cache: "no-store",

--- a/components/ui-grid/holistic-sheet.tsx
+++ b/components/ui-grid/holistic-sheet.tsx
@@ -59,13 +59,16 @@ import {
   fetchLookups,
   fetchMissingAnuncioRows,
   fetchSheetRows,
+  listVendasByCarro,
   lookupCarByPlate,
   ApiClientError,
   runFinalize,
   runRebuild,
   syncCarroCaracteristicas,
+  updateVendaEstado,
   upsertSheetRow,
-  verifyAnuncioInsight
+  verifyAnuncioInsight,
+  type VendaConcluidaRow
 } from "@/components/ui-grid/api";
 import type {
   CarFormSectionKey,
@@ -511,6 +514,7 @@ export function HolisticSheet({
   // Carros.estado_venda='VENDIDO' e setado automaticamente pelo trigger SQL
   // quando a venda e criada com estado_venda='concluida'.
   const [vendaDialogOpen, setVendaDialogOpen] = useState(false);
+  const [vendaDialogCarroId, setVendaDialogCarroId] = useState<string | null>(null);
   const [vendaDialogFormaPagamento, setVendaDialogFormaPagamento] = useState<
     "a_vista" | "financiado" | "consorcio" | "parcelado" | "misto"
   >("a_vista");
@@ -521,6 +525,19 @@ export function HolisticSheet({
   const [vendaDialogObservacao, setVendaDialogObservacao] = useState("");
   const [vendaDialogSubmitting, setVendaDialogSubmitting] = useState(false);
   const [vendaDialogError, setVendaDialogError] = useState<string | null>(null);
+
+  // Conflict dialog (aparece quando o usuario muda estado_venda em carro que
+  // ja possui venda concluida ativa). Opcoes: cancelar (estorno) ou obsoletar
+  // (venda historica, libera slot pra revenda).
+  type VendaConflictFollowUp =
+    | { kind: "open-venda-dialog"; carroId: string }
+    | { kind: "persist-cell-edit"; carroId: string; column: string; newValue: unknown }
+    | { kind: "none" };
+  const [vendaConflictOpen, setVendaConflictOpen] = useState(false);
+  const [vendaConflictVenda, setVendaConflictVenda] = useState<VendaConcluidaRow | null>(null);
+  const [vendaConflictFollowUp, setVendaConflictFollowUp] = useState<VendaConflictFollowUp>({ kind: "none" });
+  const [vendaConflictSubmitting, setVendaConflictSubmitting] = useState(false);
+  const [vendaConflictError, setVendaConflictError] = useState<string | null>(null);
 
   const splitResizeRef = useRef<SplitResizeState | null>(null);
   const formOpenRequestRef = useRef(0);
@@ -2460,6 +2477,31 @@ export function HolisticSheet({
       return;
     }
 
+    // Intercept estado_venda mudanca em carros: se virou VENDIDO sem venda
+    // ativa => abrir dialog de venda. Se ja ha venda concluida, abrir dialog
+    // de conflito antes (cancelar/obsoletar a venda anterior).
+    if (
+      activeSheet.key === "carros" &&
+      editingCell.column === "estado_venda" &&
+      pkValue
+    ) {
+      const newEstado = String(newValue ?? "").trim().toUpperCase();
+      const oldEstado = String(oldValue ?? "").trim().toUpperCase();
+      const isVendidoNow = newEstado === "VENDIDO";
+      const wasVendidoBefore = oldEstado === "VENDIDO";
+
+      if (isVendidoNow !== wasVendidoBefore) {
+        setEditingCell(null);
+        await handleEstadoVendaTransition({
+          carroId: pkValue,
+          newValue,
+          isVendidoNow,
+          precoSugerido: row.preco_original ?? null
+        });
+        return;
+      }
+    }
+
     updateLocalRow(pkValue, { [editingCell.column]: newValue });
 
     enqueuePersistence(async () => {
@@ -2474,6 +2516,65 @@ export function HolisticSheet({
     });
 
     setEditingCell(null);
+  }
+
+  /**
+   * Decide se a transicao de estado_venda no carro deve abrir o vendaDialog,
+   * o conflictDialog ou persistir direto. Chamada tanto pelo cell-edit quanto
+   * pelo submit do form (que ja removeu estado_venda do payload upstream).
+   */
+  async function handleEstadoVendaTransition(params: {
+    carroId: string;
+    newValue: unknown;
+    isVendidoNow: boolean;
+    precoSugerido?: unknown;
+  }) {
+    let existingVenda: VendaConcluidaRow | null = null;
+    try {
+      const rows = await listVendasByCarro({
+        requestAuth,
+        carroId: params.carroId,
+        estadoVenda: "concluida"
+      });
+      if (rows.length > 0) existingVenda = rows[0];
+    } catch (err) {
+      console.warn("Falha ao consultar vendas existentes do carro", err);
+    }
+
+    if (existingVenda) {
+      setVendaConflictVenda(existingVenda);
+      setVendaConflictError(null);
+      setVendaConflictFollowUp(
+        params.isVendidoNow
+          ? { kind: "open-venda-dialog", carroId: params.carroId }
+          : {
+              kind: "persist-cell-edit",
+              carroId: params.carroId,
+              column: "estado_venda",
+              newValue: params.newValue
+            }
+      );
+      setVendaConflictOpen(true);
+      return;
+    }
+
+    if (params.isVendidoNow) {
+      openVendaDialogForCarro({ carroId: params.carroId, precoSugerido: params.precoSugerido });
+      return;
+    }
+
+    // Sem venda concluida e mudando pra estado != VENDIDO: persiste direto.
+    updateLocalRow(params.carroId, { estado_venda: params.newValue });
+    enqueuePersistence(async () => {
+      await upsertSheetRow({
+        table: activeSheet.key,
+        requestAuth,
+        row: {
+          [activeSheet.primaryKey]: params.carroId,
+          estado_venda: params.newValue
+        }
+      });
+    });
   }
 
   function toggleHideSelected() {
@@ -3153,6 +3254,36 @@ export function HolisticSheet({
       row[column] = coerceSheetFormValue(column, formValues[column] ?? "");
     }
 
+    // Em update de carros, mudancas em estado_venda passam por fluxo dedicado
+    // (criar venda quando vira VENDIDO; resolver conflito quando ja ha venda
+    // concluida). Removemos do payload para nao gravar direto e disparamos o
+    // dialog apropriado apos salvar os demais campos.
+    let pendingEstadoVendaTransition: {
+      newValue: unknown;
+      isVendidoNow: boolean;
+    } | null = null;
+    if (
+      formMode === "update" &&
+      isCarSingleForm &&
+      editingRowId &&
+      "estado_venda" in row
+    ) {
+      const originalRow = viewRows.find(
+        (item) => String(item[activeSheet.primaryKey] ?? "") === editingRowId
+      );
+      const oldEstado = String(originalRow?.estado_venda ?? "").trim().toUpperCase();
+      const newEstado = String(row.estado_venda ?? "").trim().toUpperCase();
+      const isVendidoNow = newEstado === "VENDIDO";
+      const wasVendidoBefore = oldEstado === "VENDIDO";
+      if (isVendidoNow !== wasVendidoBefore) {
+        pendingEstadoVendaTransition = {
+          newValue: row.estado_venda,
+          isVendidoNow
+        };
+        delete row.estado_venda;
+      }
+    }
+
     setFormSubmitting(true);
     setFormError(null);
     setFormInfo(null);
@@ -3185,6 +3316,15 @@ export function HolisticSheet({
       } else {
         closeFormPanel();
       }
+
+      if (pendingEstadoVendaTransition && editingRowId) {
+        await handleEstadoVendaTransition({
+          carroId: editingRowId,
+          newValue: pendingEstadoVendaTransition.newValue,
+          isVendidoNow: pendingEstadoVendaTransition.isVendidoNow,
+          precoSugerido: formValues.preco_original ?? null
+        });
+      }
     } catch (err) {
       setFormError(err instanceof Error ? err.message : formMode === "update" ? "Falha ao atualizar linha." : "Falha ao inserir linha.");
     } finally {
@@ -3205,12 +3345,12 @@ export function HolisticSheet({
     }
   }
 
-  function handleFinalizeEditingRow() {
-    if (!canFinalizeSelected || activeSheet.key !== "carros" || !editingRowId || formSubmitting || !isCarFeatureDataReady) return;
-    // Abre dialog de registro de venda. Carros.estado_venda='VENDIDO' sera
-    // setado pelo trigger SQL quando a venda for criada com 'concluida'.
+  function openVendaDialogForCarro(params: { carroId: string; precoSugerido?: unknown }) {
+    setVendaDialogCarroId(params.carroId);
     setVendaDialogFormaPagamento("a_vista");
-    setVendaDialogValorTotal(String(formValues.preco_original ?? ""));
+    setVendaDialogValorTotal(
+      params.precoSugerido != null && params.precoSugerido !== "" ? String(params.precoSugerido) : ""
+    );
     setVendaDialogValorEntrada("");
     setVendaDialogCompradorNome("");
     setVendaDialogCompradorDocumento("");
@@ -3219,9 +3359,47 @@ export function HolisticSheet({
     setVendaDialogOpen(true);
   }
 
+  function handleFinalizeEditingRow() {
+    if (!canFinalizeSelected || activeSheet.key !== "carros" || !editingRowId || formSubmitting || !isCarFeatureDataReady) return;
+    // Abre dialog de registro de venda. Carros.estado_venda='VENDIDO' sera
+    // setado pelo trigger SQL quando a venda for criada com 'concluida'.
+    void requestVendaCreationFlow({
+      carroId: editingRowId,
+      precoSugerido: formValues.preco_original ?? null
+    });
+  }
+
+  /**
+   * Verifica se ja existe venda concluida para o carro. Se sim, abre o dialog
+   * de conflito (cancelar/obsoletar) com followUp = abrir vendaDialog apos
+   * resolver. Se nao, abre o vendaDialog direto.
+   */
+  async function requestVendaCreationFlow(params: { carroId: string; precoSugerido?: unknown }) {
+    try {
+      const existing = await listVendasByCarro({
+        requestAuth,
+        carroId: params.carroId,
+        estadoVenda: "concluida"
+      });
+      if (existing.length > 0) {
+        setVendaConflictVenda(existing[0]);
+        setVendaConflictFollowUp({ kind: "open-venda-dialog", carroId: params.carroId });
+        setVendaConflictError(null);
+        setVendaConflictOpen(true);
+        return;
+      }
+    } catch (err) {
+      // Se a consulta falhar, prossegue pro dialog de criar venda - o backend
+      // ainda valida com unique index e retorna 409 se houver conflito.
+      console.warn("Falha ao consultar vendas existentes do carro", err);
+    }
+    openVendaDialogForCarro(params);
+  }
+
   async function submitVendaDialog(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!editingRowId || vendaDialogSubmitting) return;
+    const carroId = vendaDialogCarroId;
+    if (!carroId || vendaDialogSubmitting) return;
 
     if (!actor.authUserId) {
       setVendaDialogError("Usuario autenticado nao identificado. Faca login novamente.");
@@ -3250,7 +3428,7 @@ export function HolisticSheet({
       await createVenda({
         requestAuth,
         payload: {
-          carro_id: editingRowId,
+          carro_id: carroId,
           vendedor_auth_user_id: actor.authUserId,
           forma_pagamento: vendaDialogFormaPagamento,
           valor_total: valorTotalParsed,
@@ -3262,6 +3440,7 @@ export function HolisticSheet({
       });
 
       setVendaDialogOpen(false);
+      setVendaDialogCarroId(null);
       await loadGrid();
       setFormInfo("Venda registrada. Veiculo marcado como vendido.");
     } catch (err) {
@@ -3269,6 +3448,50 @@ export function HolisticSheet({
       setVendaDialogError(message);
     } finally {
       setVendaDialogSubmitting(false);
+    }
+  }
+
+  /**
+   * Resolve o conflito (cancelar/obsoletar venda anterior) e, se houver um
+   * followUp pendente, executa-o (abrir vendaDialog ou persistir cell-edit).
+   */
+  async function resolveVendaConflict(action: "cancelada" | "obsoleta") {
+    const venda = vendaConflictVenda;
+    if (!venda || vendaConflictSubmitting) return;
+
+    setVendaConflictSubmitting(true);
+    setVendaConflictError(null);
+
+    try {
+      await updateVendaEstado({ requestAuth, id: venda.id, estadoVenda: action });
+
+      const followUp = vendaConflictFollowUp;
+      setVendaConflictOpen(false);
+      setVendaConflictVenda(null);
+      setVendaConflictFollowUp({ kind: "none" });
+
+      if (followUp.kind === "open-venda-dialog") {
+        openVendaDialogForCarro({ carroId: followUp.carroId });
+      } else if (followUp.kind === "persist-cell-edit") {
+        enqueuePersistence(async () => {
+          await upsertSheetRow({
+            table: activeSheet.key,
+            requestAuth,
+            row: {
+              [activeSheet.primaryKey]: followUp.carroId,
+              [followUp.column]: followUp.newValue
+            }
+          });
+        });
+        await loadGrid();
+      } else {
+        await loadGrid();
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Falha ao resolver venda anterior.";
+      setVendaConflictError(message);
+    } finally {
+      setVendaConflictSubmitting(false);
     }
   }
 
@@ -6201,6 +6424,100 @@ export function HolisticSheet({
             document.body
           )
         : null}
+      {vendaConflictOpen && vendaConflictVenda && typeof document !== "undefined"
+        ? createPortal(
+            <div className="sheet-focus-overlay" data-testid="venda-conflict-overlay">
+              <div className="sheet-focus-dialog" role="dialog" aria-modal="true" data-testid="venda-conflict-dialog">
+                <div className="sheet-form-panel-shell">
+                  <header className="sheet-focus-dialog-head">
+                    <div>
+                      <strong>Venda concluida existente</strong>
+                      <p>
+                        Este carro ja tem uma venda concluida. Decida o que fazer com a anterior
+                        antes de prosseguir.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      className="sheet-filter-clear-btn"
+                      onClick={() => {
+                        if (vendaConflictSubmitting) return;
+                        setVendaConflictOpen(false);
+                        setVendaConflictVenda(null);
+                        setVendaConflictFollowUp({ kind: "none" });
+                        setVendaConflictError(null);
+                      }}
+                      data-testid="venda-conflict-close"
+                    >
+                      Cancelar
+                    </button>
+                  </header>
+                  <div className="sheet-focus-dialog-body">
+                    <label className="sheet-form-field">
+                      <span>Data da venda</span>
+                      <input type="text" value={vendaConflictVenda.data_venda ?? "—"} readOnly />
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Valor total</span>
+                      <input
+                        type="text"
+                        value={
+                          vendaConflictVenda.valor_total != null
+                            ? new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }).format(
+                                Number(vendaConflictVenda.valor_total)
+                              )
+                            : "—"
+                        }
+                        readOnly
+                      />
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Forma de pagamento</span>
+                      <input type="text" value={vendaConflictVenda.forma_pagamento ?? "—"} readOnly />
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Comprador</span>
+                      <input type="text" value={vendaConflictVenda.comprador_nome ?? "—"} readOnly />
+                    </label>
+                    <p>
+                      <strong>Cancelar:</strong> a venda anterior some da contabilidade (foi um erro
+                      registrar).
+                      <br />
+                      <strong>Obsoletar:</strong> a venda ocorreu de fato, mas o veiculo voltou pra
+                      loja; a venda fica como historico e nao afeta mais a logica.
+                    </p>
+                    {vendaConflictError ? (
+                      <p className="sheet-error" data-testid="venda-conflict-error">
+                        {vendaConflictError}
+                      </p>
+                    ) : null}
+                    <div className="sheet-form-topbar-actions">
+                      <button
+                        type="button"
+                        className="sheet-form-submit"
+                        onClick={() => void resolveVendaConflict("cancelada")}
+                        disabled={vendaConflictSubmitting}
+                        data-testid="venda-conflict-cancel"
+                      >
+                        {vendaConflictSubmitting ? "Processando..." : "Cancelar venda anterior"}
+                      </button>
+                      <button
+                        type="button"
+                        className="sheet-form-submit"
+                        onClick={() => void resolveVendaConflict("obsoleta")}
+                        disabled={vendaConflictSubmitting}
+                        data-testid="venda-conflict-obsolete"
+                      >
+                        {vendaConflictSubmitting ? "Processando..." : "Marcar como obsoleta"}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
       {vendaDialogOpen && typeof document !== "undefined"
         ? createPortal(
             <div className="sheet-focus-overlay" data-testid="venda-dialog-overlay">
@@ -6217,6 +6534,7 @@ export function HolisticSheet({
                       onClick={() => {
                         if (vendaDialogSubmitting) return;
                         setVendaDialogOpen(false);
+                        setVendaDialogCarroId(null);
                         setVendaDialogError(null);
                       }}
                       data-testid="venda-dialog-close"

--- a/components/ui-grid/holistic-sheet.tsx
+++ b/components/ui-grid/holistic-sheet.tsx
@@ -51,6 +51,7 @@ import {
   toEditable
 } from "@/components/ui-grid/value-format";
 import {
+  createVenda,
   deleteSheetRow,
   fetchCarroCaracteristicas,
   fetchLatestPriceChangeContext,
@@ -505,6 +506,22 @@ export function HolisticSheet({
     bulkSubmitting,
     setBulkSubmitting
   } = useGridCarFormState();
+  // Venda dialog (clicar "Vender" no form de carros abre este modal pra
+  // registrar a venda com vendedor + forma_pagamento + campos opcionais).
+  // Carros.estado_venda='VENDIDO' e setado automaticamente pelo trigger SQL
+  // quando a venda e criada com estado_venda='concluida'.
+  const [vendaDialogOpen, setVendaDialogOpen] = useState(false);
+  const [vendaDialogFormaPagamento, setVendaDialogFormaPagamento] = useState<
+    "a_vista" | "financiado" | "consorcio" | "parcelado" | "misto"
+  >("a_vista");
+  const [vendaDialogValorTotal, setVendaDialogValorTotal] = useState("");
+  const [vendaDialogValorEntrada, setVendaDialogValorEntrada] = useState("");
+  const [vendaDialogCompradorNome, setVendaDialogCompradorNome] = useState("");
+  const [vendaDialogCompradorDocumento, setVendaDialogCompradorDocumento] = useState("");
+  const [vendaDialogObservacao, setVendaDialogObservacao] = useState("");
+  const [vendaDialogSubmitting, setVendaDialogSubmitting] = useState(false);
+  const [vendaDialogError, setVendaDialogError] = useState<string | null>(null);
+
   const splitResizeRef = useRef<SplitResizeState | null>(null);
   const formOpenRequestRef = useRef(0);
   const secondaryGridRequestRef = useRef(0);
@@ -3188,40 +3205,70 @@ export function HolisticSheet({
     }
   }
 
-  async function handleFinalizeEditingRow() {
+  function handleFinalizeEditingRow() {
     if (!canFinalizeSelected || activeSheet.key !== "carros" || !editingRowId || formSubmitting || !isCarFeatureDataReady) return;
-    if (!window.confirm("Salvar este carro como vendido?")) return;
+    // Abre dialog de registro de venda. Carros.estado_venda='VENDIDO' sera
+    // setado pelo trigger SQL quando a venda for criada com 'concluida'.
+    setVendaDialogFormaPagamento("a_vista");
+    setVendaDialogValorTotal(String(formValues.preco_original ?? ""));
+    setVendaDialogValorEntrada("");
+    setVendaDialogCompradorNome("");
+    setVendaDialogCompradorDocumento("");
+    setVendaDialogObservacao("");
+    setVendaDialogError(null);
+    setVendaDialogOpen(true);
+  }
 
-    const row: Record<string, unknown> = {};
-    for (const column of formEditableColumns) {
-      row[column] = coerceSheetFormValue(column, formValues[column] ?? "");
+  async function submitVendaDialog(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!editingRowId || vendaDialogSubmitting) return;
+
+    if (!actor.authUserId) {
+      setVendaDialogError("Usuario autenticado nao identificado. Faca login novamente.");
+      return;
     }
 
-    row[activeSheet.primaryKey] = editingRowId;
-    row.estado_venda = "VENDIDO";
+    const parseOptionalNumber = (value: string): number | null => {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      const normalized = trimmed.replace(/\./g, "").replace(",", ".");
+      const parsed = Number(normalized);
+      return Number.isFinite(parsed) ? parsed : NaN;
+    };
 
-    setFormSubmitting(true);
-    setFormError(null);
-    setFormInfo(null);
+    const valorTotalParsed = parseOptionalNumber(vendaDialogValorTotal);
+    const valorEntradaParsed = parseOptionalNumber(vendaDialogValorEntrada);
+    if (Number.isNaN(valorTotalParsed) || Number.isNaN(valorEntradaParsed)) {
+      setVendaDialogError("Valor invalido. Use numero com decimais (ex: 50000,00).");
+      return;
+    }
+
+    setVendaDialogSubmitting(true);
+    setVendaDialogError(null);
 
     try {
-      const response = await upsertRowWithPriceContextSafe({ table: activeSheet.key, row });
-      const carroId = String(response.row.id ?? editingRowId);
-
-      await syncCarroCaracteristicas({
-        carroId,
-        caracteristicasVisuaisIds: selectedVisualFeatureIds,
-        caracteristicasTecnicasIds: selectedTechnicalFeatureIds,
-        requestAuth
+      await createVenda({
+        requestAuth,
+        payload: {
+          carro_id: editingRowId,
+          vendedor_auth_user_id: actor.authUserId,
+          forma_pagamento: vendaDialogFormaPagamento,
+          valor_total: valorTotalParsed,
+          valor_entrada: valorEntradaParsed,
+          comprador_nome: vendaDialogCompradorNome.trim() || null,
+          comprador_documento: vendaDialogCompradorDocumento.trim() || null,
+          observacao: vendaDialogObservacao.trim() || null
+        }
       });
 
+      setVendaDialogOpen(false);
       await loadGrid();
-      setFormValues(buildInitialFormValuesFromRow(response.row));
-      setFormInfo("Veiculo marcado como vendido.");
+      setFormInfo("Venda registrada. Veiculo marcado como vendido.");
     } catch (err) {
-      setFormError(err instanceof Error ? err.message : "Falha ao salvar veiculo como vendido.");
+      const message = err instanceof Error ? err.message : "Falha ao registrar venda.";
+      setVendaDialogError(message);
     } finally {
-      setFormSubmitting(false);
+      setVendaDialogSubmitting(false);
     }
   }
 
@@ -6145,6 +6192,120 @@ export function HolisticSheet({
                         disabled={featureQuickCreateSubmitting}
                       >
                         {featureQuickCreateSubmitting ? "Salvando..." : "Salvar caracteristica"}
+                      </button>
+                    </div>
+                  </div>
+                </form>
+              </div>
+            </div>,
+            document.body
+          )
+        : null}
+      {vendaDialogOpen && typeof document !== "undefined"
+        ? createPortal(
+            <div className="sheet-focus-overlay" data-testid="venda-dialog-overlay">
+              <div className="sheet-focus-dialog" role="dialog" aria-modal="true" data-testid="venda-dialog">
+                <form className="sheet-form-panel-shell" onSubmit={submitVendaDialog}>
+                  <header className="sheet-focus-dialog-head">
+                    <div>
+                      <strong>Registrar venda</strong>
+                      <p>Vendedor: voce. Demais campos podem ser preenchidos depois no grid de vendas.</p>
+                    </div>
+                    <button
+                      type="button"
+                      className="sheet-filter-clear-btn"
+                      onClick={() => {
+                        if (vendaDialogSubmitting) return;
+                        setVendaDialogOpen(false);
+                        setVendaDialogError(null);
+                      }}
+                      data-testid="venda-dialog-close"
+                    >
+                      Fechar
+                    </button>
+                  </header>
+                  <div className="sheet-focus-dialog-body">
+                    <label className="sheet-form-field">
+                      <span>Forma de pagamento *</span>
+                      <select
+                        value={vendaDialogFormaPagamento}
+                        onChange={(event) =>
+                          setVendaDialogFormaPagamento(event.target.value as typeof vendaDialogFormaPagamento)
+                        }
+                        data-testid="venda-dialog-forma-pagamento"
+                      >
+                        <option value="a_vista">A vista</option>
+                        <option value="financiado">Financiado</option>
+                        <option value="consorcio">Consorcio</option>
+                        <option value="parcelado">Parcelado</option>
+                        <option value="misto">Misto</option>
+                      </select>
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Valor total</span>
+                      <input
+                        type="text"
+                        inputMode="decimal"
+                        value={vendaDialogValorTotal}
+                        onChange={(event) => setVendaDialogValorTotal(event.target.value)}
+                        data-testid="venda-dialog-valor-total"
+                        placeholder="Opcional"
+                      />
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Valor de entrada</span>
+                      <input
+                        type="text"
+                        inputMode="decimal"
+                        value={vendaDialogValorEntrada}
+                        onChange={(event) => setVendaDialogValorEntrada(event.target.value)}
+                        data-testid="venda-dialog-valor-entrada"
+                        placeholder="Opcional"
+                      />
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Nome do comprador</span>
+                      <input
+                        type="text"
+                        value={vendaDialogCompradorNome}
+                        onChange={(event) => setVendaDialogCompradorNome(event.target.value)}
+                        data-testid="venda-dialog-comprador-nome"
+                        placeholder="Opcional"
+                      />
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Documento do comprador (CPF/CNPJ)</span>
+                      <input
+                        type="text"
+                        value={vendaDialogCompradorDocumento}
+                        onChange={(event) => setVendaDialogCompradorDocumento(event.target.value)}
+                        data-testid="venda-dialog-comprador-documento"
+                        placeholder="Opcional"
+                      />
+                    </label>
+                    <label className="sheet-form-field">
+                      <span>Observacao</span>
+                      <textarea
+                        value={vendaDialogObservacao}
+                        onChange={(event) => setVendaDialogObservacao(event.target.value)}
+                        rows={2}
+                        data-testid="venda-dialog-observacao"
+                        placeholder="Opcional"
+                      />
+                    </label>
+                    {vendaDialogError ? (
+                      <p className="sheet-error" data-testid="venda-dialog-error">
+                        {vendaDialogError}
+                      </p>
+                    ) : null}
+                    <div className="sheet-form-topbar-actions">
+                      <button
+                        type="submit"
+                        className="sheet-form-submit"
+                        data-testid="venda-dialog-submit"
+                        disabled={vendaDialogSubmitting}
+                      >
+                        {vendaDialogSubmitting ? "Registrando..." : "Registrar venda"}
                       </button>
                     </div>
                   </div>

--- a/lib/domain/vendas/__tests__/schemas.test.ts
+++ b/lib/domain/vendas/__tests__/schemas.test.ts
@@ -4,13 +4,11 @@ import { vendaCreateSchema, vendaUpdateSchema } from "@/lib/domain/vendas/schema
 const baseCreate = {
   carro_id: "b13a82d4-0000-4000-8000-000000000001",
   vendedor_auth_user_id: "b13a82d4-0000-4000-8000-000000000002",
-  valor_total: 50000,
-  forma_pagamento: "a_vista" as const,
-  comprador_nome: "Joao Silva"
+  forma_pagamento: "a_vista" as const
 };
 
 describe("vendaCreateSchema", () => {
-  it("accepts minimal valid payload (so campos obrigatorios)", () => {
+  it("accepts minimal valid payload (carro + vendedor + forma_pagamento)", () => {
     const result = vendaCreateSchema.safeParse(baseCreate);
     expect(result.success).toBe(true);
   });
@@ -25,9 +23,14 @@ describe("vendaCreateSchema", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects comprador_nome vazio", () => {
-    const result = vendaCreateSchema.safeParse({ ...baseCreate, comprador_nome: "   " });
-    expect(result.success).toBe(false);
+  it("aceita comprador_nome ausente (opcional)", () => {
+    const result = vendaCreateSchema.safeParse(baseCreate);
+    expect(result.success).toBe(true);
+  });
+
+  it("aceita estado_venda 'obsoleta'", () => {
+    const result = vendaCreateSchema.safeParse({ ...baseCreate, estado_venda: "obsoleta" });
+    expect(result.success).toBe(true);
   });
 
   it("rejects carro_id nao-uuid", () => {

--- a/lib/domain/vendas/schemas.ts
+++ b/lib/domain/vendas/schemas.ts
@@ -14,12 +14,10 @@ import { z } from "zod";
  */
 
 const FORMA_PAGAMENTO_VALUES = ["a_vista", "financiado", "consorcio", "parcelado", "misto"] as const;
-const ESTADO_VENDA_VALUES = ["concluida", "cancelada"] as const;
+const ESTADO_VENDA_VALUES = ["concluida", "cancelada", "obsoleta"] as const;
 
 export const FORMA_PAGAMENTO_OPTIONS = FORMA_PAGAMENTO_VALUES;
 export const VENDA_ESTADO_OPTIONS = ESTADO_VENDA_VALUES;
-
-const trimmedString = (max: number) => z.string().trim().min(1).max(max);
 
 const optionalNullableString = (max: number) =>
   z
@@ -60,16 +58,17 @@ const baseFields = {
   carro_id: uuid,
   vendedor_auth_user_id: uuid,
 
-  // Dados basicos
+  // Dados basicos (so vendedor + forma_pagamento sao obrigatorios; preco e
+  // comprador podem ser preenchidos depois)
   data_venda: isoDate.optional(),
-  valor_total: nonNegativeNumber,
+  valor_total: optionalNonNegativeNumber,
   valor_entrada: optionalNonNegativeNumber,
   forma_pagamento: z.enum(FORMA_PAGAMENTO_VALUES),
   estado_venda: z.enum(ESTADO_VENDA_VALUES).optional(),
   observacao: optionalNullableString(4000),
 
-  // Comprador
-  comprador_nome: trimmedString(160),
+  // Comprador (todos opcionais agora)
+  comprador_nome: optionalNullableString(160),
   comprador_documento: optionalNullableString(40),
   comprador_telefone: optionalNullableString(40),
   comprador_email: optionalNullableString(160),
@@ -113,7 +112,7 @@ export const vendaUpdateSchema = z
     forma_pagamento: z.enum(FORMA_PAGAMENTO_VALUES).optional(),
     estado_venda: z.enum(ESTADO_VENDA_VALUES).optional(),
     observacao: optionalNullableString(4000),
-    comprador_nome: trimmedString(160).optional(),
+    comprador_nome: optionalNullableString(160),
     comprador_documento: optionalNullableString(40),
     comprador_telefone: optionalNullableString(40),
     comprador_email: optionalNullableString(160),

--- a/lib/domain/vendas/service.ts
+++ b/lib/domain/vendas/service.ts
@@ -15,6 +15,7 @@ export type ListVendasInput = {
   pageSize: number;
   estadoVenda?: string | null;
   vendedorAuthUserId?: string | null;
+  carroId?: string | null;
 };
 
 export type ListVendasOutput = {
@@ -59,7 +60,7 @@ function ensureVendorScope(actor: ActorContext, targetVendedorAuthId: string | u
 }
 
 export async function listVendas(input: ListVendasInput): Promise<ListVendasOutput> {
-  const { supabase, page, pageSize, estadoVenda, vendedorAuthUserId } = input;
+  const { supabase, page, pageSize, estadoVenda, vendedorAuthUserId, carroId } = input;
   const from = Math.max(0, (page - 1) * pageSize);
   const to = from + pageSize - 1;
 
@@ -77,6 +78,9 @@ export async function listVendas(input: ListVendasInput): Promise<ListVendasOutp
   }
   if (vendedorAuthUserId?.trim()) {
     query = query.eq("vendedor_auth_user_id", vendedorAuthUserId.trim());
+  }
+  if (carroId?.trim()) {
+    query = query.eq("carro_id", carroId.trim());
   }
 
   const { data, error, count } = await query.range(from, to);

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -1215,7 +1215,7 @@ export type Database = {
           comprador_documento: string | null
           comprador_email: string | null
           comprador_endereco: string | null
-          comprador_nome: string
+          comprador_nome: string | null
           comprador_telefone: string | null
           created_at: string
           created_by_user_id: string | null
@@ -1240,7 +1240,7 @@ export type Database = {
           troca_valor: number | null
           updated_at: string
           valor_entrada: number | null
-          valor_total: number
+          valor_total: number | null
           vendedor_auth_user_id: string
         }
         Insert: {
@@ -1248,7 +1248,7 @@ export type Database = {
           comprador_documento?: string | null
           comprador_email?: string | null
           comprador_endereco?: string | null
-          comprador_nome: string
+          comprador_nome?: string | null
           comprador_telefone?: string | null
           created_at?: string
           created_by_user_id?: string | null
@@ -1273,7 +1273,7 @@ export type Database = {
           troca_valor?: number | null
           updated_at?: string
           valor_entrada?: number | null
-          valor_total: number
+          valor_total?: number | null
           vendedor_auth_user_id: string
         }
         Update: {
@@ -1281,7 +1281,7 @@ export type Database = {
           comprador_documento?: string | null
           comprador_email?: string | null
           comprador_endereco?: string | null
-          comprador_nome?: string
+          comprador_nome?: string | null
           comprador_telefone?: string | null
           created_at?: string
           created_by_user_id?: string | null
@@ -1306,7 +1306,7 @@ export type Database = {
           troca_valor?: number | null
           updated_at?: string
           valor_entrada?: number | null
-          valor_total?: number
+          valor_total?: number | null
           vendedor_auth_user_id?: string
         }
         Relationships: [

--- a/supabase/migrations/20260516180000_vendas_relax_required_and_add_obsoleta.sql
+++ b/supabase/migrations/20260516180000_vendas_relax_required_and_add_obsoleta.sql
@@ -1,0 +1,37 @@
+-- Afrouxa obrigatoriedade do registro de venda e adiciona estado 'obsoleta'.
+--
+-- Mudancas:
+-- - valor_total: vira nullable (operador pode registrar venda sem preco e
+--   preencher depois).
+-- - comprador_nome: vira nullable (venda anonima/cadastro de comprador
+--   incremental).
+-- - estado_venda: aceita 'obsoleta' alem de 'concluida'/'cancelada'.
+--
+-- Semantica dos estados:
+--   concluida (default): venda valida e contabilizada; ocupa o slot do
+--     unique partial index, encadeia carros.estado_venda='VENDIDO'.
+--   cancelada: venda desfeita (erro/cliente desistiu). NAO ocupa o slot,
+--     nao surte efeito na logica. Operador decide se reverte estado do
+--     carro manualmente.
+--   obsoleta: venda DE FATO aconteceu mas o carro voltou para a loja e
+--     pode ser vendido de novo. Preserva historico, nao ocupa o slot,
+--     nao surte efeito na logica. Distinta de cancelada porque o
+--     comprador efetivamente comprou em algum momento.
+--
+-- O partial unique index (where estado_venda='concluida') ja restringe
+-- corretamente, entao obsoleta libera o slot para nova venda.
+
+alter table public.vendas
+  alter column valor_total drop not null,
+  alter column comprador_nome drop not null;
+
+alter table public.vendas
+  drop constraint if exists vendas_estado_venda_check;
+
+alter table public.vendas
+  add constraint vendas_estado_venda_check
+    check (estado_venda in ('concluida', 'cancelada', 'obsoleta'));
+
+comment on column public.vendas.valor_total is 'Valor total da venda (opcional). NULL = preenche depois.';
+comment on column public.vendas.comprador_nome is 'Nome do comprador (opcional). NULL = cadastro depois.';
+comment on column public.vendas.estado_venda is 'concluida (venda valida, ocupa slot) | cancelada (desfeita, sem efeito) | obsoleta (carro retornou a loja, historico mantido).';


### PR DESCRIPTION
## Summary
- **Phase 1 (schema)**: `valor_total` e `comprador_nome` opcionais; novo estado `obsoleta` em `vendas.estado_venda` (venda historica que liberou o slot do carro).
- **Phase 2 (UI - Vender)**: botao "Vender" no form de carros agora abre dialog que registra a venda via `POST /api/v1/vendas`. O trigger SQL cascateia `carros.estado_venda='VENDIDO'`. Campos: forma_pagamento (obrigatorio), valor_total/valor_entrada/comprador_nome/comprador_documento/observacao (opcionais).
- **Phase 3 (UI - auto-trigger + conflito)**: mudancas manuais de `estado_venda` (cell-edit ou form) sao interceptadas e abrem o fluxo apropriado:
  - VENDIDO sem venda anterior -> venda dialog
  - VENDIDO com venda concluida -> conflict dialog (cancelar/obsoletar) -> venda dialog
  - VENDIDO -> outro estado com venda concluida -> conflict dialog -> persiste mudanca
- Backend: filtro `carro_id` em `GET /api/v1/vendas` + helpers `listVendasByCarro` / `updateVendaEstado` no client.

## Test plan
- [x] `npx tsc --noEmit` limpo
- [x] `npx vitest run lib/domain/vendas` 15 testes passando
- [x] `npx next lint` sem warnings
- [ ] Manual no navegador: criar carro novo -> "Vender" -> registrar venda -> verificar `estado_venda=VENDIDO`
- [ ] Manual: mudar `estado_venda` direto na celula para VENDIDO -> dialog abre
- [ ] Manual: tentar revender carro ja com venda concluida -> conflict dialog aparece
- [ ] Manual: voltar VENDIDO -> DISPONIVEL com venda concluida -> conflict dialog -> obsoletar -> estado_venda persiste

## Migrations
- `supabase/migrations/20260516180000_vendas_relax_required_and_add_obsoleta.sql` (ja aplicada localmente; precisa rodar em outros ambientes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)